### PR TITLE
Fix bug when applying migrations repeatedly

### DIFF
--- a/spec/init_pg.sh
+++ b/spec/init_pg.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-USER = postgres
-DB = "clear_spec"
-
-psql -U $USER -C "DROP IF EXISTS DATABASE $DB; CREATE DATABASE $DB;"
-psql -U $USER -d $DB "CREATE TABLE users(id integer PRIMARY, first_name );"

--- a/spec/migration/migration_spec.cr
+++ b/spec/migration/migration_spec.cr
@@ -70,4 +70,15 @@ module MigrationSpec
       end
     end
   end
+
+  temporary do
+    describe "Migration" do
+      it "can run migrations apply_all multiple times" do
+        Clear::Migration::Manager.instance.reinit!
+        # Ensure that multiple migration apply_all's can run without issue
+        Clear::Migration::Manager.instance.apply_all
+        Clear::Migration::Manager.instance.apply_all
+      end
+    end
+  end
 end

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -72,11 +72,11 @@ module ModelSpec
     end
   end
 
-  Clear::Migration::Manager.instance.reinit!
-  ModelSpecMigration123.new.apply(Clear::Migration::Direction::UP)
+  temporary do
+    Clear::Migration::Manager.instance.reinit!
+    ModelSpecMigration123.new.apply(Clear::Migration::Direction::UP)
 
-  describe "Clear::Model" do
-    temporary do
+    describe "Clear::Model" do
       context "fields management" do
         it "can load from array" do
           temporary do

--- a/src/clear/migration/manager.cr
+++ b/src/clear/migration/manager.cr
@@ -137,9 +137,12 @@ class Clear::Migration::Manager
     ensure_ready
 
     list_of_migrations = @migrations.sort { |a, b| a.uid <=> b.uid }
-    list_of_migrations.reject! { |x| @migrations_up.includes?(x) }
+    list_of_migrations.reject! { |x| @migrations_up.includes?(x.uid) }
 
-    list_of_migrations.each(&.apply(Clear::Migration::Direction::UP))
+    list_of_migrations.each do |migration|
+      migration.apply(Clear::Migration::Direction::UP)
+      @migrations_up.add(migration.uid)
+    end
   end
 
   #


### PR DESCRIPTION
When going through a POC without dropping the DB in between runs, ran into a bug on subsequent runs when it tried to apply the DummyMigration again (and record that it was applied).