### PR TITLE
WIP: Support Multiple connections

### DIFF
--- a/spec/model/multiple_connections.cr
+++ b/spec/model/multiple_connections.cr
@@ -1,0 +1,81 @@
+require "../spec_helper"
+
+module MultipleConnectionsSpec
+  class Post
+    include Clear::Model
+
+    self.table = "models_posts"
+
+    column id : Int32, primary: true, presence: false
+    column title : String
+  end
+
+  class PostStat
+    include Clear::Model
+
+    self.connection = "secondary"
+    self.table = "models_post_stats"
+
+    column id : Int32, primary: true, presence: false
+    column post_id : Int32
+  end
+
+  class ModelSpecMigration1234
+    include Clear::Migration
+
+    def change(dir)
+      create_table "models_posts" do |t|
+        t.string "title", index: true
+      end
+    end
+  end
+
+  def self.reinit
+    reinit_migration_manager
+    ModelSpecMigration1234.new.apply(Clear::Migration::Direction::UP)
+    init_secondary_db
+  end
+
+  describe "Clear::Model" do
+    context "multiple connections" do
+      it "know about the different connections on models" do
+        Post.connection.should eq "default"
+        PostStat.connection.should eq "secondary"
+      end
+
+      it "can load data from the default database" do
+        temporary do
+          reinit
+
+          p = Post.new({title: "some post"})
+          p.save
+          p.persisted?.should be_true
+        end
+      end
+
+      it "can insert data into the secondary database" do
+        temporary do
+          reinit
+           p = PostStat.new({post_id: 1})
+           p.save
+           p.persisted?.should be_true
+           p.post_id.should eq(1)
+        end
+      end
+
+      it "can update data on the secondary database" do
+        temporary do
+          reinit
+          p = PostStat.new({post_id: 1})
+          p.save
+
+          p.post_id = 2
+          p.save
+
+          p = PostStat.query.first.not_nil!
+          p.post_id.should eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/model/multiple_connections_spec.cr
+++ b/spec/model/multiple_connections_spec.cr
@@ -33,7 +33,6 @@ module MultipleConnectionsSpec
   def self.reinit
     reinit_migration_manager
     ModelSpecMigration1234.new.apply(Clear::Migration::Direction::UP)
-    init_secondary_db
   end
 
   describe "Clear::Model" do
@@ -46,7 +45,6 @@ module MultipleConnectionsSpec
       it "can load data from the default database" do
         temporary do
           reinit
-
           p = Post.new({title: "some post"})
           p.save
           p.persisted?.should be_true
@@ -56,10 +54,10 @@ module MultipleConnectionsSpec
       it "can insert data into the secondary database" do
         temporary do
           reinit
-           p = PostStat.new({post_id: 1})
-           p.save
-           p.persisted?.should be_true
-           p.post_id.should eq(1)
+          p = PostStat.new({post_id: 1})
+          p.save
+          p.persisted?.should be_true
+          p.post_id.should eq(1)
         end
       end
 
@@ -69,11 +67,21 @@ module MultipleConnectionsSpec
           p = PostStat.new({post_id: 1})
           p.save
 
+          p = PostStat.query.first.not_nil!
           p.post_id = 2
           p.save
 
           p = PostStat.query.first.not_nil!
           p.post_id.should eq(2)
+        end
+      end
+
+      it "can update data on the secondary database" do
+        temporary do
+          reinit
+          p = PostStat.new({post_id: 1})
+          p.save
+          p.delete.should be_true
         end
       end
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -19,7 +19,7 @@ def init_secondary_db
   system("echo \"DROP DATABASE IF EXISTS clear_secondary_spec;\" | psql -U postgres")
   system("echo \"CREATE DATABASE clear_secondary_spec;\" | psql -U postgres")
   system("echo \"CREATE TABLE models_post_stats (id serial PRIMARY KEY, post_id INTEGER);\" | psql -U postgres clear_secondary_spec")
-  system("echo \"INSERT INTO models_post_stats VALUES (1, 1);\" | psql -U postgres clear_secondary_spec")
+  # system("echo \"INSERT INTO models_post_stats VALUES (1, 1);\" | psql -U postgres clear_secondary_spec")
 
   Clear::SQL.init({
     "deafult" => "postgres://postgres@localhost/clear_spec",

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -6,7 +6,14 @@ def initdb
   system("echo \"DROP DATABASE IF EXISTS clear_spec;\" | psql -U postgres")
   system("echo \"CREATE DATABASE clear_spec;\" | psql -U postgres")
 
-  Clear::SQL.init("postgres://postgres@localhost/clear_spec")
+  system("echo \"DROP DATABASE IF EXISTS clear_secondary_spec;\" | psql -U postgres")
+  system("echo \"CREATE DATABASE clear_secondary_spec;\" | psql -U postgres")
+  system("echo \"CREATE TABLE models_post_stats (id serial PRIMARY KEY, post_id INTEGER);\" | psql -U postgres clear_secondary_spec")
+
+  Clear::SQL.init({
+    "default" => "postgres://postgres@localhost/clear_spec",
+    "secondary" => "postgres://postgres@localhost/clear_secondary_spec",
+  })
 
   {% if flag?(:quiet) %}
     Clear.logger.level = ::Logger::ERROR
@@ -15,20 +22,8 @@ def initdb
   {% end %}
 end
 
-def init_secondary_db
-  system("echo \"DROP DATABASE IF EXISTS clear_secondary_spec;\" | psql -U postgres")
-  system("echo \"CREATE DATABASE clear_secondary_spec;\" | psql -U postgres")
-  system("echo \"CREATE TABLE models_post_stats (id serial PRIMARY KEY, post_id INTEGER);\" | psql -U postgres clear_secondary_spec")
-  # system("echo \"INSERT INTO models_post_stats VALUES (1, 1);\" | psql -U postgres clear_secondary_spec")
-
-  Clear::SQL.init({
-    "deafult" => "postgres://postgres@localhost/clear_spec",
-    "secondary" => "postgres://postgres@localhost/clear_secondary_spec",
-  })
-end
-
 def reinit_migration_manager
-    Clear::Migration::Manager.instance.reinit!
+  Clear::Migration::Manager.instance.reinit!
 end
 
 def temporary(&block)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -15,6 +15,18 @@ def initdb
   {% end %}
 end
 
+def init_secondary_db
+  system("echo \"DROP DATABASE IF EXISTS clear_secondary_spec;\" | psql -U postgres")
+  system("echo \"CREATE DATABASE clear_secondary_spec;\" | psql -U postgres")
+  system("echo \"CREATE TABLE models_post_stats (id serial PRIMARY KEY, post_id INTEGER);\" | psql -U postgres clear_secondary_spec")
+  system("echo \"INSERT INTO models_post_stats VALUES (1, 1);\" | psql -U postgres clear_secondary_spec")
+
+  Clear::SQL.init({
+    "deafult" => "postgres://postgres@localhost/clear_spec",
+    "secondary" => "postgres://postgres@localhost/clear_secondary_spec",
+  })
+end
+
 def reinit_migration_manager
     Clear::Migration::Manager.instance.reinit!
 end

--- a/src/clear/model/model.cr
+++ b/src/clear/model/model.cr
@@ -14,6 +14,7 @@ module Clear::Model
   include Clear::Model::HasValidation
   include Clear::Model::HasRelations
   include Clear::Model::HasScope
+  include Clear::Model::Connection
   include Clear::Model::ClassMethods
   include Clear::Model::IsPolymorphic
 

--- a/src/clear/model/model.cr
+++ b/src/clear/model/model.cr
@@ -6,6 +6,7 @@ require "./converter/**"
 require "./validation/**"
 
 module Clear::Model
+  include Clear::Model::Connection
   include Clear::Model::HasColumns
   include Clear::Model::HasHooks
   include Clear::Model::HasTimestamps
@@ -14,7 +15,6 @@ module Clear::Model
   include Clear::Model::HasValidation
   include Clear::Model::HasRelations
   include Clear::Model::HasScope
-  include Clear::Model::Connection
   include Clear::Model::ClassMethods
   include Clear::Model::IsPolymorphic
 

--- a/src/clear/model/modules/class_methods.cr
+++ b/src/clear/model/modules/class_methods.cr
@@ -20,7 +20,7 @@ module Clear::Model::ClassMethods
       class Collection < Clear::Model::CollectionBase(\{{@type}}); end
 
       def self.query
-        Collection.new.from(table)
+        Collection.new.use_connection(connection).from(table)
       end
 
       def self.find(x)

--- a/src/clear/model/modules/connection.cr
+++ b/src/clear/model/modules/connection.cr
@@ -1,0 +1,7 @@
+module Clear::Model::Connection
+  macro included # When included into Model
+    macro included # When included into final Model
+      class_property connection : Clear::SQL::Symbolic = "default"
+    end
+  end
+end

--- a/src/clear/model/modules/has_saving.cr
+++ b/src/clear/model/modules/has_saving.cr
@@ -26,7 +26,7 @@ module Clear::Model::HasSaving
         else
           with_triggers(:create) do
             @persisted = true
-            hash = Clear::SQL.insert_into(self.class.table, to_h).returning("*").execute
+            hash = Clear::SQL.insert_into(@@connection, self.class.table, to_h).returning("*").execute
             self.set(hash)
           end
         end

--- a/src/clear/model/modules/has_saving.cr
+++ b/src/clear/model/modules/has_saving.cr
@@ -20,7 +20,7 @@ module Clear::Model::HasSaving
 
           if h.any?
             with_triggers(:update) do
-              Clear::SQL.update(self.class.table).set(update_h).where { var("#{self.class.pkey}") == pkey }.execute
+              Clear::SQL.update(@@connection, self.class.table).set(update_h).where { var("#{self.class.pkey}") == pkey }.execute
             end
           end
         else
@@ -54,7 +54,7 @@ module Clear::Model::HasSaving
     return false unless persisted?
 
     with_triggers(:delete) do
-      Clear::SQL::DeleteQuery.new.from(self.class.table).where{ var("#{self.class.pkey}") == pkey }.execute
+      Clear::SQL::DeleteQuery.new(@@connection).from(self.class.table).where{ var("#{self.class.pkey}") == pkey }.execute
 
       @persisted = false
       clear_change_flags

--- a/src/clear/sql/delete_query.cr
+++ b/src/clear/sql/delete_query.cr
@@ -3,12 +3,21 @@ require "./query/*"
 class Clear::SQL::DeleteQuery
   getter from : Symbolic?
 
+  include Query::Connection
   include Query::Where
   include Query::Execute
   include Query::Change
 
   def initialize(@from = nil,
                  @wheres = [] of Clear::Expression::Node)
+    @connection = "default"
+    @connection_name = "default"
+  end
+
+  def initialize(@connection : Symbolic,
+                 @from = nil,
+                 @wheres = [] of Clear::Expression::Node)
+    @connection_name = @connection
   end
 
   def from(x)

--- a/src/clear/sql/insert_query.cr
+++ b/src/clear/sql/insert_query.cr
@@ -27,13 +27,17 @@ class Clear::SQL::InsertQuery
   getter returning : String?
 
   def initialize(@table : Selectable)
+    @connection = "default"
+  end
+
+  def initialize(@connection : Symbolic, @table : Selectable)
   end
 
   def fetch(&block : Hash(String, ::Clear::SQL::Any) -> Void)
     Clear::SQL.log_query to_sql do
       h = {} of String => ::Clear::SQL::Any
 
-      Clear::SQL.connection(self.connection_name).query(to_sql) do |rs|
+      Clear::SQL.connection(@connection).query(to_sql) do |rs|
         fetch_result_set(h, rs) { |x| yield(x) }
       end
     end
@@ -61,6 +65,11 @@ class Clear::SQL::InsertQuery
     o = {} of String => ::Clear::SQL::Any
 
     if @returning.nil?
+      puts "="* 50
+      puts self.connection_name
+      puts to_sql
+      puts "="* 50
+
       Clear::SQL.execute(self.connection_name, to_sql)
     else
       # return {} of String => ::Clear::SQL::Any

--- a/src/clear/sql/insert_query.cr
+++ b/src/clear/sql/insert_query.cr
@@ -18,6 +18,7 @@ require "./query/*"
 #
 class Clear::SQL::InsertQuery
   include Query::Change
+  include Query::Connection
 
   alias Inserable = ::Clear::SQL::Any | BigInt | BigFloat | Time
   getter keys : Array(Symbolic) = [] of Symbolic
@@ -32,7 +33,7 @@ class Clear::SQL::InsertQuery
     Clear::SQL.log_query to_sql do
       h = {} of String => ::Clear::SQL::Any
 
-      Clear::SQL.connection.query(to_sql) do |rs|
+      Clear::SQL.connection(self.connection_name).query(to_sql) do |rs|
         fetch_result_set(h, rs) { |x| yield(x) }
       end
     end

--- a/src/clear/sql/insert_query.cr
+++ b/src/clear/sql/insert_query.cr
@@ -61,7 +61,7 @@ class Clear::SQL::InsertQuery
     o = {} of String => ::Clear::SQL::Any
 
     if @returning.nil?
-      Clear::SQL.execute(to_sql)
+      Clear::SQL.execute(self.connection_name, to_sql)
     else
       # return {} of String => ::Clear::SQL::Any
       fetch { |x| o = x; break }

--- a/src/clear/sql/insert_query.cr
+++ b/src/clear/sql/insert_query.cr
@@ -65,11 +65,6 @@ class Clear::SQL::InsertQuery
     o = {} of String => ::Clear::SQL::Any
 
     if @returning.nil?
-      puts "="* 50
-      puts self.connection_name
-      puts to_sql
-      puts "="* 50
-
       Clear::SQL.execute(self.connection_name, to_sql)
     else
       # return {} of String => ::Clear::SQL::Any

--- a/src/clear/sql/query/connection.cr
+++ b/src/clear/sql/query/connection.cr
@@ -1,0 +1,9 @@
+module Clear::SQL
+  module Query::Connection
+    getter connection_name : Symbolic = "default"
+
+    def use_connection(@connection_name : Symbolic)
+      self
+    end
+  end
+end

--- a/src/clear/sql/query/execute.cr
+++ b/src/clear/sql/query/execute.cr
@@ -2,6 +2,6 @@ require "db"
 
 module Clear::SQL::Query::Execute
   def execute
-    Clear::SQL.execute(to_sql)
+    Clear::SQL.execute(self.connection_name, to_sql)
   end
 end

--- a/src/clear/sql/query/fetch.cr
+++ b/src/clear/sql/query/fetch.cr
@@ -23,7 +23,7 @@ module Clear::SQL::Query::Fetch
     trigger_before_query
 
     Clear::SQL.transaction do
-      cnx = Clear::SQL.connection
+      cnx = Clear::SQL.connection(self.connection_name)
       cursor_name = "__cursor_#{Time.now.epoch ^ (rand * 0xfffffff).to_i}__"
 
       cursor_declaration = "DECLARE #{cursor_name} CURSOR FOR #{to_sql}"
@@ -55,7 +55,7 @@ module Clear::SQL::Query::Fetch
     trigger_before_query
 
     Clear::SQL.log_query to_sql do
-      Clear::SQL.connection.scalar(to_sql).as(T)
+      Clear::SQL.connection(self.connection_name).scalar(to_sql).as(T)
     end
   end
 
@@ -71,7 +71,7 @@ module Clear::SQL::Query::Fetch
     to_sql = self.to_sql
 
     rs = uninitialized PG::ResultSet
-    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection.query(to_sql) }
+    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection(self.connection_name).query(to_sql) }
 
     o = [] of Hash(String, ::Clear::SQL::Any)
     fetch_result_set(h, rs) { |x| o << x.dup }
@@ -92,7 +92,8 @@ module Clear::SQL::Query::Fetch
     to_sql = self.to_sql
 
     rs = uninitialized PG::ResultSet
-    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection.query(to_sql) }
+
+    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection(connection_name).query(to_sql) }
 
     if fetch_all
       o = [] of Hash(String, ::Clear::SQL::Any)

--- a/src/clear/sql/query/fetch.cr
+++ b/src/clear/sql/query/fetch.cr
@@ -23,7 +23,7 @@ module Clear::SQL::Query::Fetch
     trigger_before_query
 
     Clear::SQL.transaction do
-      cnx = Clear::SQL.connection(self.connection_name)
+      cnx = Clear::SQL.connection(connection_name)
       cursor_name = "__cursor_#{Time.now.epoch ^ (rand * 0xfffffff).to_i}__"
 
       cursor_declaration = "DECLARE #{cursor_name} CURSOR FOR #{to_sql}"
@@ -55,7 +55,7 @@ module Clear::SQL::Query::Fetch
     trigger_before_query
 
     Clear::SQL.log_query to_sql do
-      Clear::SQL.connection(self.connection_name).scalar(to_sql).as(T)
+      Clear::SQL.connection(connection_name).scalar(to_sql).as(T)
     end
   end
 
@@ -71,7 +71,7 @@ module Clear::SQL::Query::Fetch
     to_sql = self.to_sql
 
     rs = uninitialized PG::ResultSet
-    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection(self.connection_name).query(to_sql) }
+    Clear::SQL.log_query(to_sql) { rs = Clear::SQL.connection(connection_name).query(to_sql) }
 
     o = [] of Hash(String, ::Clear::SQL::Any)
     fetch_result_set(h, rs) { |x| o << x.dup }

--- a/src/clear/sql/select_builder.cr
+++ b/src/clear/sql/select_builder.cr
@@ -17,6 +17,7 @@ module Clear::SQL::SelectBuilder
   end
 
   include Query::Change
+  include Query::Connection
   include Query::Select
   include Query::From
   include Query::Join

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -181,12 +181,24 @@ module Clear
 
     # Start an INSERT INTO table query
     def insert_into(table, *args)
-      Clear::SQL::InsertQuery.new(table).insert(*args)
+      Clear::SQL::InsertQuery.new("default", table).insert(*args)
+    end
+
+    def insert_into(connection : Symbolic, table, *args)
+      Clear::SQL::InsertQuery.new(connection, table).insert(*args)
     end
 
     # Alias of `insert_into`, for hurry developers
     def insert(table, *args)
-      insert_into(table, *args)
+      insert_into("default", table, *args)
+    end
+
+    def insert(table, args : NamedTuple)
+      insert_into("default", table, args)
+    end
+
+    def insert(connection : Symbolic, table, *args)
+      insert_into(connection, table, *args)
     end
 
     # Start a UPDATE table query

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -176,7 +176,11 @@ module Clear
 
     # Start a DELETE table query
     def delete(table = nil)
-      Clear::SQL::DeleteQuery.new(from: table)
+      Clear::SQL::DeleteQuery.new("default", from: table)
+    end
+
+    def delete(connection : Symbolic, table = nil)
+      Clear::SQL::DeleteQuery.new(connection, from: table)
     end
 
     # Start an INSERT INTO table query
@@ -203,7 +207,11 @@ module Clear
 
     # Start a UPDATE table query
     def update(table)
-      Clear::SQL::UpdateQuery.new(table)
+      Clear::SQL::UpdateQuery.new("default", table)
+    end
+
+    def update(connection : Symbolic, table)
+      Clear::SQL::UpdateQuery.new(connection, table)
     end
 
     # Start a SELECT FROM table query

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -161,6 +161,14 @@ module Clear
       log_query(sql) { Clear::SQL.connection("default").exec(sql) }
     end
 
+    # Execute a SQL request on a specific connection.
+    #
+    # Usage:
+    # Clear::SQL.execute("seconddatabase", "SELECT 1 FROM users")
+    def execute(connection : Symbolic, sql)
+      log_query(sql) { Clear::SQL.connection(connection).exec(sql) }
+    end
+
     # :nodoc:
     def sel_str(s : Selectable)
       s.is_a?(Symbolic) ? s.to_s : s.to_sql

--- a/src/clear/sql/update_query.cr
+++ b/src/clear/sql/update_query.cr
@@ -8,14 +8,23 @@ class Clear::SQL::UpdateQuery
   alias UpdateInstruction = Hash(String, Updatable) | String
 
   @values : Array(UpdateInstruction) = [] of UpdateInstruction
+  @connection : Symbolic
   @table : String
 
+  include Query::Connection
   include Query::Change
   include Query::Where
   include Query::Execute
 
   def initialize(table, @wheres = [] of Clear::Expression::Node)
     @table = table.to_s
+    @connection = "default"
+    @connection_name = "default"
+  end
+
+  def initialize(@connection : Symbolic, table, @wheres = [] of Clear::Expression::Node)
+    @table = table.to_s
+    @connection_name = @connection
   end
 
   def set(row : NamedTuple)


### PR DESCRIPTION
This is still a work in progress.

Changes the interface for initing databases to:
```
Clear::SQL.init({
  "default" => "postgres://postgres@localhost/databse1",
  "secondary" => "postgres://postgres@localhost/database2",
})
```

It does still support:
```
Clear::SQL.init("postgres://postgres@localhost/databse1")
```

On the models, you can specify which connection to use. It will default to "default".
```
self.connection = "secondary"
```

This PR is still a bit messy as I'm trying to shove this in place. One of main things I'm concerned/trying to avoid is migrations working on secondary connections at all.