### PR TITLE
Only set persisted = true if there were no exceptions

### DIFF
--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -139,7 +139,7 @@ module ModelSpec
         end
       end
 
-      it "can detect persistance" do
+      it "can detect persistence" do
         temporary do
           reinit
           u = User.new({id: 1}, persisted: true)
@@ -206,6 +206,23 @@ module ModelSpec
 
           u.id.should eq(1)       # Should be set
           p.user!.id.should eq(1) # And should be set
+        end
+      end
+
+      it "does not set persisted on failed insert" do
+        temporary do
+          reinit
+          user_info = UserInfo.new({registration_number: 123, user_id: 999})
+
+          begin
+            user_info.save!.should be_false
+          rescue ex
+            user_info.persisted?.should be_false
+            User.create({id: 999})
+          ensure
+            user_info.save!.should be_true
+            user_info.persisted?.should be_true
+          end
         end
       end
 

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -212,17 +212,24 @@ module ModelSpec
       it "does not set persisted on failed insert" do
         temporary do
           reinit
+          # There's no user_id = 999
           user_info = UserInfo.new({registration_number: 123, user_id: 999})
 
-          begin
-            user_info.save!.should be_false
-          rescue ex
-            user_info.persisted?.should be_false
-            User.create({id: 999})
-          ensure
-            user_info.save!.should be_true
-            user_info.persisted?.should be_true
+          expect_raises(Exception) do
+            user_info.save! # Should raise exception
           end
+
+          user_info.persisted?.should be_false
+        end
+
+        temporary do
+          reinit
+
+          User.create!({id: 999, first_name: "Test"})
+          user_info = UserInfo.new({registration_number: 123, user_id: 999})
+
+          user_info.save.should be_true
+          user_info.persisted?.should be_true
         end
       end
 

--- a/src/clear/model/modules/has_saving.cr
+++ b/src/clear/model/modules/has_saving.cr
@@ -25,9 +25,14 @@ module Clear::Model::HasSaving
           end
         else
           with_triggers(:create) do
-            @persisted = true
-            hash = Clear::SQL.insert_into(self.class.table, to_h).returning("*").execute(@@connection)
-            self.set(hash)
+            begin
+              hash = Clear::SQL.insert_into(self.class.table, to_h).returning("*").execute(@@connection)
+            rescue ex
+              raise ex
+            else
+              @persisted = true
+              self.set(hash)
+            end
           end
         end
 


### PR DESCRIPTION
## Description
Wraps the `save` method in a begin/rescue/else block.  This allows the `persisted` variable to only be set to true if there was no exception raised from the db insert.

This fixes #39 