### PR TITLE
A method to add a new connection after instantiation.

### DIFF
--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -87,6 +87,10 @@ module Clear
       # end
     end
 
+    def add_connection(name : String, url : String, connection_pool_size = 5)
+      Clear::SQL::ConnectionPool.init(url, name, connection_pool_size)
+    end
+
     @@in_transaction : Bool = false
     @@savepoint_uid : UInt64 = 0_u64
 


### PR DESCRIPTION
Adding a add_connection method to SQL. This allows you to create a new connection after the initial instantiation.

We have a case where we need to connect to a different database based on what libraries in are shard are being required.

I've tested locally with this change and have not had any issues.