### PR TITLE
Add virtual field support (fix #68)

### DIFF
--- a/spec/model/cache_spec.cr
+++ b/spec/model/cache_spec.cr
@@ -13,10 +13,10 @@ module CacheSpec
       Category.create [{id: 201, name: "Test"}]
       Category.create [{id: 202, name: "Test 2"}]
 
-      Post.create [{id: 301, name: "Post 1", published: true, user_id: 101, category_id: 201, content: "Lorem ipsum"}]
-      Post.create [{id: 302, name: "Post 2", published: true, user_id: 102, category_id: 201, content: "Lorem ipsum"}]
-      Post.create [{id: 303, name: "Post 2", published: true, user_id: 102, category_id: 202, content: "Lorem ipsum"}]
-      Post.create [{id: 304, name: "Post 2", published: true, user_id: 101, category_id: 202, content: "Lorem ipsum"}]
+      Post.create [{id: 301, published: true, user_id: 101, category_id: 201, content: "Lorem ipsum"}]
+      Post.create [{id: 302, published: true, user_id: 102, category_id: 201, content: "Lorem ipsum"}]
+      Post.create [{id: 303, published: true, user_id: 102, category_id: 202, content: "Lorem ipsum"}]
+      Post.create [{id: 304, published: true, user_id: 101, category_id: 202, content: "Lorem ipsum"}]
 
       context "cache system" do
         it "manage has_many relations" do

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -80,6 +80,15 @@ module ModelSpec
 
     timestamps
 
+    # Random virtual method
+    def full_name=(x)
+      self.first_name, self.last_name = x.split(" ")
+    end
+
+    def full_name
+      {self.first_name, self.last_name}.join(" ")
+    end
+
     self.table = "model_users"
   end
 
@@ -348,6 +357,17 @@ module ModelSpec
 
           u = User.query.select({full_name: "first_name || ' ' || last_name"}).first!(fetch_columns: true)
           u["full_name"].should eq "a b"
+        end
+      end
+
+      it "can create a model using virtual fields" do
+        temporary do
+          reinit
+          User.create!(full_name: "Hello World")
+
+          u = User.query.first!
+          u.first_name.should eq "Hello"
+          u.last_name.should eq "World"
         end
       end
 

--- a/src/clear/model/modules/has_columns.cr
+++ b/src/clear/model/modules/has_columns.cr
@@ -144,6 +144,8 @@ module Clear::Model::HasColumns
        } %}
   end
 
+
+
   # :nodoc:
   # Used internally to gather the columns
   macro __generate_columns
@@ -186,8 +188,23 @@ module Clear::Model::HasColumns
       {% end %}
     {% end %}
 
+
+    def set( **t : **T ) forall T
+      \{% for name, typ in T %}
+        \{% if !@type.has_method?("#{name}=") %}
+          \{% raise "No method #{@type}##{name}= while trying to set value of #{name}" %}
+        \{% end %}
+
+        \{% if settings = COLUMNS["#{name}".id] %}
+          @\{{name}}_column.reset(Clear::Model::Converter.to_column(\{{settings[:converter]}}, t[:\{{name}}]))
+        \{% else %}
+          self.\{{name}} = t[:\{{name}}]
+        \{% end %}
+      \{% end %}
+    end
+
     def set( t : NamedTuple )
-      set(t.to_h)
+      set(**t)
     end
 
     # Set the columns from hash


### PR DESCRIPTION
Revamp the `Model#set` method when usage of NamedTuple.

The behavior of `Model#set` is now changing according to this rule:

- If a hash is passed as parameter, it will ignore the fields which are not columns
- If a NamedTuple is passed as parameter, it will try to call all setter related to the fields which exists in the model. This allow to create model passing non-persisted fields value in `create` and `build`.

This should also improve slightly the performance of the ORM when creating model using NamedTuple, as NamedTuple is not casted to hash before processing anymore.