### PR TITLE
Fix #74 problem with `belongs_to` 

### DIFF
--- a/spec/model/uuid_spec.cr
+++ b/spec/model/uuid_spec.cr
@@ -15,7 +15,7 @@ module UUIDSpec
       end
 
     end
-    
+
   end
 
   class DBObject
@@ -36,7 +36,7 @@ module UUIDSpec
     self.table = "dbobjects2"
 
     belongs_to db_object : DBObject, foreign_key: "db_object_id", key_type: UUID?
-    
+
     with_serial_pkey type: :uuid
   end
 

--- a/spec/model/uuid_spec.cr
+++ b/spec/model/uuid_spec.cr
@@ -5,10 +5,17 @@ module UUIDSpec
     include Clear::Migration
 
     def change(dir)
+
       create_table(:dbobjects, id: :uuid) do |t|
         t.string :name, null: false
       end
+
+      create_table(:dbobjects2, id: :uuid) do |t|
+        t.references to: "dbobjects", name: "db_object_id", type: "uuid"
+      end
+
     end
+    
   end
 
   class DBObject
@@ -17,7 +24,20 @@ module UUIDSpec
     self.table = "dbobjects"
 
     with_serial_pkey type: :uuid
+
+    has_many db_object : DBObject, foreign_key: "db_object_id"
+
     column name : String
+  end
+
+  class DBObject2
+    include Clear::Model
+
+    self.table = "dbobjects2"
+
+    belongs_to db_object : DBObject, foreign_key: "db_object_id", key_type: UUID?
+    
+    with_serial_pkey type: :uuid
   end
 
   def self.reinit
@@ -47,6 +67,23 @@ module UUIDSpec
         DBObject.query.where { id == UUID.random }.count.should eq 0
         # Where with string version of UUID
         DBObject.query.where { id == "#{first_uuid}" }.count.should eq 1
+      end
+    end
+
+    it "can call relations between the objects" do
+      temporary do
+        reinit
+
+        3.times do |x|
+          DBObject.create!({name: "obj#{x}"})
+        end
+
+        dbo_id = DBObject.query.first!.id
+        DBObject2.create!({db_object_id: dbo_id})
+
+        obj = DBObject2.query.first!
+        obj.db_object.not_nil!.id.should eq dbo_id
+
       end
     end
 

--- a/src/clear/model/column.cr
+++ b/src/clear/model/column.cr
@@ -6,7 +6,7 @@ require "db"
 #   - Raise error if we try to access the value of a field
 #     which is not gathered through the query system (uninitialized column).
 #     Or use the `get_def` to get with default value
-class Clear::Model::Column(T)
+class Clear::Model::Column(T, C)
   include Clear::ErrorMessages
 
   struct UnknownClass
@@ -32,6 +32,11 @@ class Clear::Model::Column(T)
     @value.as(T)
   end
 
+  # Return the database converted value using the converter
+  def to_sql_value(default = nil) : Clear::SQL::Any
+    C.to_db(value(default))
+  end
+
   # Returns the current value of this column or `default` if the value is undefined.
   def value(default : X) : T | X forall X
     defined? ? @value.as(T) : default
@@ -45,6 +50,10 @@ class Clear::Model::Column(T)
     end
 
     @value
+  end
+
+  def reset_convert(x)
+    reset( C.to_column x )
   end
 
   # Reset the current field.

--- a/src/clear/model/converter/uuid_converter.cr
+++ b/src/clear/model/converter/uuid_converter.cr
@@ -7,6 +7,8 @@ class Clear::Model::Converter::UUIDConverter
       UUID.new(x)
     when Slice(UInt8)
       UUID.new(x)
+    when UUID
+      x
     else
       raise "Cannot convert from #{x.class} to UUID"
     end

--- a/src/clear/model/modules/has_columns.cr
+++ b/src/clear/model/modules/has_columns.cr
@@ -151,7 +151,7 @@ module Clear::Model::HasColumns
       {% type = settings[:type] %}
       {% has_db_default = !settings[:presence] %}
       {% converter = Clear::Model::Converter::CONVERTERS[settings[:converter]] %}
-      @{{name}}_column : Clear::Model::Column({{type}}, {{converter}}) = 
+      @{{name}}_column : Clear::Model::Column({{type}}, {{converter}}) =
         Clear::Model::Column({{type}}, {{converter}}).new("{{name}}",
         has_db_default: {{has_db_default}} )
 

--- a/src/clear/model/modules/has_columns.cr
+++ b/src/clear/model/modules/has_columns.cr
@@ -144,21 +144,21 @@ module Clear::Model::HasColumns
        } %}
   end
 
-
-
   # :nodoc:
   # Used internally to gather the columns
   macro __generate_columns
     {% for name, settings in COLUMNS %}
       {% type = settings[:type] %}
       {% has_db_default = !settings[:presence] %}
-      @{{name}}_column : Clear::Model::Column({{type}}) = Clear::Model::Column({{type}}).new("{{name}}",
+      {% converter = Clear::Model::Converter::CONVERTERS[settings[:converter]] %}
+      @{{name}}_column : Clear::Model::Column({{type}}, {{converter}}) = 
+        Clear::Model::Column({{type}}, {{converter}}).new("{{name}}",
         has_db_default: {{has_db_default}} )
 
       # Returns the column object used to manage `{{name}}` field
       #
       # See `Clear::Model::Column`
-      def {{name}}_column : Clear::Model::Column({{type}})
+      def {{name}}_column : Clear::Model::Column({{type}}, {{converter}})
         @{{name}}_column
       end
 
@@ -196,7 +196,7 @@ module Clear::Model::HasColumns
         \{% end %}
 
         \{% if settings = COLUMNS["#{name}".id] %}
-          @\{{name}}_column.reset(Clear::Model::Converter.to_column(\{{settings[:converter]}}, t[:\{{name}}]))
+          @\{{name}}_column.reset_convert(t[:\{{name}}])
         \{% else %}
           self.\{{name}} = t[:\{{name}}]
         \{% end %}
@@ -213,7 +213,7 @@ module Clear::Model::HasColumns
 
       {% for name, settings in COLUMNS %}
         v = h.fetch(:{{settings[:column_name]}}){ Column::UNKNOWN }
-        @{{name}}_column.reset(Clear::Model::Converter.to_column({{settings[:converter]}}, v)) unless v.is_a?(Column::UnknownClass)
+        @{{name}}_column.reset_convert(v) unless v.is_a?(Column::UnknownClass)
       {% end %}
     end
 
@@ -224,7 +224,7 @@ module Clear::Model::HasColumns
       {% for name, settings in COLUMNS %}
         if @{{name}}_column.defined? &&
            @{{name}}_column.changed?
-          o[{{settings[:column_name]}}] = Clear::Model::Converter.to_db({{settings[:converter]}}, @{{name}}_column.value)
+          o[{{settings[:column_name]}}] = @{{name}}_column.to_sql_value
         end
       {% end %}
 
@@ -265,7 +265,7 @@ module Clear::Model::HasColumns
 
       {% for name, settings in COLUMNS %}
         if full || @{{name}}_column.defined?
-          out[{{settings[:column_name]}}] = Clear::Model::Converter.to_db({{settings[:converter]}}, @{{name}}_column.value(nil))
+          out[{{settings[:column_name]}}] = @{{name}}_column.to_sql_value(nil)
         end
       {% end %}
 
@@ -288,7 +288,7 @@ module Clear::Model::HasColumns
 
       {% for name, settings in COLUMNS %}
         if h.has_key?({{settings[:column_name]}})
-          @{{name}}_column.reset(Clear::Model::Converter.to_column({{settings[:converter]}}, h[{{settings[:column_name]}}]))
+          @{{name}}_column.reset_convert(h[{{settings[:column_name]}}])
         end
       {% end %}
     end

--- a/src/clear/model/modules/relations/belongs_to_macro.cr
+++ b/src/clear/model/modules/relations/belongs_to_macro.cr
@@ -15,7 +15,7 @@ module Clear::Model::Relations::BelongsToMacro
         cache = @cache
 
         if cache && cache.active? "{{method_name}}"
-          @cached_{{method_name}} = cache.hit("{{method_name}}", 
+          @cached_{{method_name}} = cache.hit("{{method_name}}",
             self.{{foreign_key.id}}_column.to_sql_value, {{relation_type}}
           ).first?
         else

--- a/src/clear/model/modules/relations/belongs_to_macro.cr
+++ b/src/clear/model/modules/relations/belongs_to_macro.cr
@@ -15,7 +15,9 @@ module Clear::Model::Relations::BelongsToMacro
         cache = @cache
 
         if cache && cache.active? "{{method_name}}"
-          @cached_{{method_name}} = cache.hit("{{method_name}}", self.{{foreign_key.id}}, {{relation_type}}).first?
+          @cached_{{method_name}} = cache.hit("{{method_name}}", 
+            self.{{foreign_key.id}}_column.to_sql_value, {{relation_type}}
+          ).first?
         else
           @cached_{{method_name}} = {{relation_type}}.query.where{ raw({{relation_type}}.pkey) == self.{{foreign_key.id}} }.first
         end


### PR DESCRIPTION
Fix #74 problem with `belongs_to` having `foreign_key` which is not a type of the union Clear::SQL::Any.

It change the conversion system by adding the conversion module as generic parameter in the column itself, and adding two methods in the column: `to_sql_value` and `reset_convert`.

- `to_sql_value` returns the value of the column after the field has been converted to a type belonging to Clear::SQL::Any.
- `reset_convert ` allow to pass Clear::SQL::Any in input of the column and will store the converted value if conversion is necessary.