### PR TITLE
Raise RecordNotFoundError for find!

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,3 +664,7 @@ All contributions are welcome ! As a specialized ORM for PostgreSQL,
 be sure a great contribution on a very specific PG feature will be incorporated
 to this shard.
 I hope one day we will cover all the features of PG here !
+
+### Running Tests
+
+In order to run the test suite, you will need to have the PostgresSQL service locally available via a socket for access with psql. psql will attempt to use the 'postgres' user to create the test database. If you are working with a newly installed database that may not have the postgres user, this can be created with `createuser -s postgres`.

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -495,6 +495,16 @@ module ModelSpec
         end
       end
 
+      it "raises a RecordNotFoundError for an empty find!" do
+        temporary do
+          reinit
+
+          expect_raises(Clear::SQL::RecordNotFoundError) do
+            User.find!(1)
+          end
+        end
+      end
+
       it "can set back a field to nil" do
         temporary do
           reinit

--- a/src/clear/model/modules/class_methods.cr
+++ b/src/clear/model/modules/class_methods.cr
@@ -106,7 +106,7 @@ module Clear::Model::ClassMethods
       # Returns a model using primary key equality.
       # Raises error if the model is not found.
       def self.find!(x)
-        find(x).not_nil!
+        find(x) || raise Clear::SQL::RecordNotFoundError.new
       end
 
       # Build a new empty model and fill the columns using the NamedTuple in argument.

--- a/src/clear/sql/errors.cr
+++ b/src/clear/sql/errors.cr
@@ -7,6 +7,8 @@ module Clear::SQL
 
   class OperationNotPermittedError < Error; end
 
+  class RecordNotFoundError < Error; end
+
   # Rollback the transaction or the last savepoint.
   class RollbackError < Error; end
 


### PR DESCRIPTION
## Description

fixes #94

Opt to use a Clear provided RecordNotFoundError class when performing a dangerous find!. This has the advantage of allowing the consumer to use error paths to control handling of unresolved records.

Same approach as https://api.rubyonrails.org/classes/ActiveRecord/RecordNotFound.html


## Motivation and Context

Allows a consumer to handle unresolved find! calls through their error handling paths rather than relying on the generic NilAssertion error currently raise.

## How Has This Been Tested?
Unit test added

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
^ _technically_ breaking, exposed error method has been changed.

- [ ] Manual of usage of the new feature.
^ Unchanged but happy to add this.

## Checklist:
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
