### PR TITLE
Fix #93 `belongs_to` 

### DIFF
--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -74,7 +74,7 @@ module ModelSpec
     column notification_preferences : JSON::Any, presence: false
 
     has_many posts : Post, foreign_key: "user_id"
-    has_one info : UserInfo, foreign_key: "user_id"
+    has_one info : UserInfo?, foreign_key: "user_id"
     has_many categories : Category, through: :model_posts,
       own_key: :user_id, foreign_key: :category_id
 
@@ -326,12 +326,12 @@ module ModelSpec
           p.user = u
           p.save.should eq(false) # < Must save the user first. but user is missing is first name !
 
-          p.user!.first_name = "I fix the issue!" # < Fix the issue
+          p.user.first_name = "I fix the issue!" # < Fix the issue
 
           p.save.should eq(true) # Should save now
 
           u.id.should eq(1)       # Should be set
-          p.user!.id.should eq(1) # And should be set
+          p.user.id.should eq(1) # And should be set
         end
       end
 

--- a/spec/model/uuid_spec.cr
+++ b/spec/model/uuid_spec.cr
@@ -34,7 +34,7 @@ module UUIDSpec
 
     self.table = "dbobjects2"
 
-    belongs_to db_object : DBObject, foreign_key: "db_object_id", key_type: UUID?
+    belongs_to db_object : DBObject?, foreign_key: "db_object_id", key_type: UUID?
 
     primary_key type: :uuid
   end
@@ -73,7 +73,7 @@ module UUIDSpec
       temporary do
         reinit
 
-	3.times do |x|
+      	3.times do |x|
           DBObject.create!({name: "obj#{x}"})
         end
 

--- a/src/clear/model/collection.cr
+++ b/src/clear/model/collection.cr
@@ -513,7 +513,7 @@ module Clear::Model
     # Get the first row from the collection query.
     # if not found, throw an error
     def first!(fetch_columns = false) : T
-      first(fetch_columns).not_nil!
+      first(fetch_columns) || raise Clear::SQL::RecordNotFoundError.new
     end
 
     # Get the first row from the collection query.

--- a/src/clear/model/reflection/column.cr
+++ b/src/clear/model/reflection/column.cr
@@ -12,7 +12,8 @@ class Clear::Reflection::Column
   column table_name : String
   column column_name : String, primary: true
 
-  belongs_to table : Clear::Reflection::Table, foreign_key: "table_name", key_type: String
+  belongs_to table : Clear::Reflection::Table?, foreign_key: "table_name", key_type: String
+
   # def table : Clear::Reflection::Table
   #   Column.query.where { var("table_name") == self.table_name }.first
   # end


### PR DESCRIPTION
## Description

- Cannot be nil unless the relation is declared as `Relation?` 
- This will enforce presence on the foreign key
- This will disallow nil attribution for the relation etc...

## Motivation and Context

Crystal lang enforces type checking on compile time; Clear enforces it by using column wrapping system which allow the columns to be in a `undefined` stats instead of nil. But `belongs_to` were currently not enforced and the relations was nilable

## How Has This Been Tested?

In progress. I'll test this branch on my prod project, eventually build some tests to ensure it works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
