### PR TITLE
Fixes syntax error in primary key error message

### DIFF
--- a/src/clear/model/modules/has_serial_pkey.cr
+++ b/src/clear/model/modules/has_serial_pkey.cr
@@ -20,7 +20,7 @@ module Clear::Model::HasSerialPkey
     {% if cb %}
       {{cb.gsub(/__name__/, name).id}}
     {% else %}
-      { raise "Cannot define primary key of type #{type}. Candidates are: #{PKEY_TYPE.keys.join(", ")}" %}
+      {% raise "Cannot define primary key of type #{type}. Candidates are: #{PKEY_TYPE.keys.join(", ")}" %}
     {% end %}
   end
 


### PR DESCRIPTION
## Description
Fixes syntax error, now correctly lists out available key types

## Motivation and Context
Simple bug fix

## How Has This Been Tested?

1. Changed a model to an invalid primary key type `:asdf`
2. Observed syntax error being shown
3. Applied fix
4. Correct available types now listed when invalid type is passed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
