### PR TITLE
Count queries need to use the same connection as the sub query.

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   ameba:
     github: veelenga/ameba
-    commit: d2b36047ef910defda7fb9acb6816a6fa6b6e917
+    commit: 94e1d4567aec6d5101bcf11b11f107ec1da66e8d
 
   db:
     github: crystal-lang/crystal-db
@@ -22,5 +22,5 @@ shards:
 
   pg:
     github: will/crystal-pg
-    version: 0.15.0
+    version: 0.16.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -29,6 +29,6 @@ development_dependencies:
     github: veelenga/ameba
     branch: master
 
-crystal: 0.27.2
+crystal: 0.28
 
 license: MIT

--- a/src/clear/expression/expression.cr
+++ b/src/clear/expression/expression.cr
@@ -144,7 +144,7 @@ class Clear::Expression
   # Clear::Expression[Time.now, date: true] # < "2017-04-03"
   # ```
   def self.safe_literal(x : Time, date : Bool = false) : String
-    {"'", x.to_s(date ? DATABASE_DATE_FORMAT : DATABASE_DATE_TIME_FORMAT), "'"}.join
+    {"'", x.to_utc.to_s(date ? DATABASE_DATE_FORMAT : DATABASE_DATE_TIME_FORMAT), "'"}.join
   end
 
   # :nodoc:

--- a/src/clear/sql/query/aggregate.cr
+++ b/src/clear/sql/query/aggregate.cr
@@ -1,5 +1,4 @@
 module Clear::SQL::Query::Aggregate
-
   # Use SQL `COUNT` over your query, and return this number as a Int64
   #
   # as count return always a scalar, the usage of `COUNT(*) OVER GROUP BY` can be done by
@@ -17,7 +16,7 @@ module Clear::SQL::Query::Aggregate
 
       # Optimize returning 1 if found, as we count only...
       # ... except if the subquery has distinct, otherwise will always returns "1"...
-      subquery = self.is_distinct? ? self : self.dup.clear_order_bys.clear_select.select("1")
+      subquery = self.is_distinct? ? self : self.dup.clear_order_bys.clear_select.use_connection(self.connection_name).select("1")
 
       o = X.new(Clear::SQL.select("COUNT(*)").from({query_count: subquery}).scalar(Int64))
     else
@@ -32,7 +31,7 @@ module Clear::SQL::Query::Aggregate
   # Call an custom aggregation function, like MEDIAN or other:
   #
   # ```
-  #   query.agg("MEDIAN(age)", Int64)
+  # query.agg("MEDIAN(age)", Int64)
   # ```
   #
   # Note than COUNT, MIN, MAX, SUM and AVG are already conveniently mapped.


### PR DESCRIPTION
When running a count on the query, the parent query is using the default connection instead of the one provided.

## Description
Adding a use_connection on the count query.

## How Has This Been Tested?
Locally for now. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
