### PR TITLE
Fix #121 

### DIFF
--- a/spec/extensions/bcrypt_spec.cr
+++ b/spec/extensions/bcrypt_spec.cr
@@ -17,7 +17,7 @@ module BCryptSpec
   class User
     include Clear::Model
 
-    primary_key type: :uuid
+    primary_key :id, type: :uuid
 
     self.table = "bcrypt_users"
 

--- a/spec/model/json_spec.cr
+++ b/spec/model/json_spec.cr
@@ -13,7 +13,7 @@ module ModelSpec
       u.last_name.should eq "boss"
       u.changed?.should eq false
 
-      json2 = JSON.parse(%<{"tags": ["a", "b", "c"], "flags": [1, 2, 3]}>)
+      json2 = JSON.parse(%<{"tags": ["a", "b", "c"], "flags_other_column_name": [1, 2, 3]}>)
 
       p = Post.new(json2)
       p.tags.should eq ["a", "b", "c"]

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -36,7 +36,7 @@ module ModelSpec
     column title : String
 
     column tags : Array(String), presence: false
-    column flags : Array(Int64), presence: false
+    column flags : Array(Int64), presence: false, column_name: "flags_other_column_name"
 
     def validate
       ensure_than(title, "is not empty", &.size.>(0))
@@ -123,7 +123,7 @@ module ModelSpec
         t.column "title", "string", index: true
 
         t.column "tags", "string", array: true, index: "gin", default: "ARRAY['post', 'arr 2']"
-        t.column "flags", "bigint", array: true, index: "gin", default: "'{}'::bigint[]"
+        t.column "flags_other_column_name", "bigint", array: true, index: "gin", default: "'{}'::bigint[]"
 
         t.references to: "model_users", name: "user_id", on_delete: "cascade"
         t.references to: "model_categories", name: "category_id", null: true, on_delete: "set null"

--- a/src/clear/extensions/time/interval.cr
+++ b/src/clear/extensions/time/interval.cr
@@ -85,11 +85,11 @@ end
 
 struct Time
   def +(i : Clear::Interval)
-    self + i.microseconds.microseconds + i.days.days + i.months.months
+    self + i.months.months + i.days.days + i.microseconds.microseconds
   end
 
   def -(i : Clear::Interval)
-    self - i.microseconds.microseconds - i.days.days - i.months.months
+    self - i.months.months - i.days.days - i.microseconds.microseconds
   end
 end
 


### PR DESCRIPTION
Allow column_name option to be used to select a different name for mapping between model's variable and table's column.

## Motivation and Context

The option was here already long time ago but never been tested. The option regressed until someone noticed it (#121)

## How Has This Been Tested?

A small test has been written to ensure than fundamentals are working. Since I need to rework the test sets, a bigger test set should be done later.

## Types of changes

Should not break anything, but change a lot the macros so who knows...

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
