### PR TITLE
fix delete and unlink

### DIFF
--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -688,6 +688,23 @@ module ModelSpec
           p.tag_relations.offset(1).first!.name.should eq("Why not")
         end
       end
+
+      it "can unlink has_many through" do
+        temporary do
+          reinit
+
+          u = User.create!({first_name: "John"})
+          c = Category.create!({name: "Nature"})
+          p = Post.create!({title: "Post about Poneys", user_id: u.id, category_id: c.id})
+
+          p.tag_relations << Tag.new({name: "Awesome"})
+          p.tag_relations << Tag.new({name: "Why not"})
+
+          p.tag_relations.count.should eq(2)
+          p.tag_relations.unlink(Tag.query.find!({name: "Awesome"}))
+          p.tag_relations.count.should eq(1)
+        end
+      end
     end
 
     context "with join" do

--- a/src/clear/migration/migration.cr
+++ b/src/clear/migration/migration.cr
@@ -123,7 +123,7 @@ module Clear::Migration
           op.down.each { |x| Clear::SQL.execute(x.as(String)) }
         }
 
-        SQL.delete("default", "__clear_metadatas").where({metatype: "migration", value: uid.to_s}).execute
+        SQL.delete("__clear_metadatas").where({metatype: "migration", value: uid.to_s}).execute
       end
 
       self

--- a/src/clear/model/collection.cr
+++ b/src/clear/model/collection.cr
@@ -430,7 +430,7 @@ module Clear::Model
       raise "Operation not permitted on this collection." unless unlink_operation
 
       unlink_operation.call(item)
-      @cached_result.try &.remove(item)
+      @cached_result.try &.delete(item)
 
       self
     end

--- a/src/clear/sql/delete_query.cr
+++ b/src/clear/sql/delete_query.cr
@@ -1,27 +1,26 @@
 require "./query/*"
 
 class Clear::SQL::DeleteQuery
-  getter from : Symbolic?
+  getter table : Symbolic?
 
   include Query::Connection
   include Query::Where
   include Query::Execute
   include Query::Change
 
-  def initialize(@from = nil,
-                 @wheres = [] of Clear::Expression::Node)
+  def initialize(@table = nil, @wheres = [] of Clear::Expression::Node)
   end
 
-  def from(x)
-    @from = x
+  def from(table)
+    @table = table
     change!
   end
 
   def to_sql
-    raise Clear::ErrorMessages.query_building_error("Delete Query must have a `from` clause.") unless from = @from
+    raise Clear::ErrorMessages.query_building_error("Delete Query must have a `from` clause.") unless table = @table
 
-    from = from.is_a?(Symbol) ? SQL.escape(from.to_s) : from
+    table = table.is_a?(Symbol) ? SQL.escape(table.to_s) : table
 
-    ["DELETE FROM", from, print_wheres].compact.join(" ")
+    ["DELETE FROM", table, print_wheres].compact.join(" ")
   end
 end

--- a/src/clear/sql/select_builder.cr
+++ b/src/clear/sql/select_builder.cr
@@ -90,7 +90,7 @@ module Clear::SQL::SelectBuilder
 
     raise QueryBuildingError.new("Cannot delete from a select with sub-select as `from` clause") if v.is_a?(SelectBuilder)
 
-    DeleteQuery.new(from: v.dup, wheres: @wheres.dup)
+    DeleteQuery.new(v.dup, @wheres.dup)
   end
 
   def to_update

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -250,13 +250,8 @@ module Clear
     end
 
     # Start a DELETE table query
-    def delete(table = nil)
-      Clear::SQL::DeleteQuery.new("default").from(table)
-    end
-
-    # Start a DELETE table query on specific connection
-    def delete(connection : Symbolic, table = nil)
-      Clear::SQL::DeleteQuery.new(connection).from(table)
+    def delete(table : Symbolic)
+      Clear::SQL::DeleteQuery.new.from(table)
     end
 
     # Start an INSERT INTO table query


### PR DESCRIPTION
I'm trying to implement tagging from scratch in Clear.

First error when calling `#unlink` method:

```
Showing last frame. Use --error-trace for full trace.

In lib/clear/src/clear/model/collection.cr:428:28

 428 | @cached_result.try &.remove(item)
                            ^-----
Error: undefined method 'remove' for Array(Tag)
```

I believe it's just a typo.

Second error:

```
Unhandled exception: You're trying to construct an invalid SQL request:
Delete Query must have a `from` clause.

You may want to check the manual:

https://github.com/anykeyh/clear/tree/master/manual/querying/RequestBuilding.md

You may also have encountered a bug. 
Feel free to submit an issue: 
https://github.com/anykeyh/clear/issues/new
```

I noticed that `delete` functionality is outdated/broken.

I'm not sure why `def delete(connection : Symbolic, table = nil)` was implemented. But I didn't find where it used. So I removed it. Correct me if I'm wrong

Additional notes:

* [x] Add specs for `#unlink`