### PR TITLE
fix Clear::Migration::Execute

### DIFF
--- a/src/clear/migration/migration.cr
+++ b/src/clear/migration/migration.cr
@@ -72,8 +72,8 @@ module Clear::Migration
       raise IrreversibleMigration.new(migration_irreversible(self.class.name))
     end
 
-    def execute(up : String? = nil, down : String? = nil)
-      @operations << Clear::Migration::Execute.new( up, down )
+    def execute(sql : String)
+      @operations << Clear::Migration::Execute.new(sql)
     end
 
     def add_operation(op : Operation)

--- a/src/clear/migration/operation/execute.cr
+++ b/src/clear/migration/operation/execute.cr
@@ -2,20 +2,16 @@ require "./operation"
 
 module Clear::Migration
   class Execute < Operation
-    @up : String?
-    @down : String?
-    @irreversible : Bool
-
-    def initialize(@up = nil, @down = nil, @irreversible = false)
+    def initialize(@sql : String, @irreversible : Bool? = false)
     end
 
     def up : Array(String)
-      [@up].compact
+      [@sql].compact
     end
 
     def down : Array(String)
-      irreversible! if @irreversible && @down.nil?
-      [@down].compact
+      irreversible! if @irreversible
+      [@sql].compact
     end
   end
 end


### PR DESCRIPTION
## Description

```crystal
class CreateUser
  include Clear::Migration

  def change(direction)
    direction.up do
      execute("CREATE TABLE users...")
    end

    direction.down do
      execute("DROP TABLE users")
    end
  end
end
```

Up migration works well.
Down migration never executes because `execute` method accepts 2 arguments `up` and `down`. Why?

As temporary solution `execute(nil, "DROP TABLE my_models")` can be used. But without reasons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
