### PR TITLE
inserting uuid properties with nil now works

### DIFF
--- a/spec/model/converter_spec.cr
+++ b/spec/model/converter_spec.cr
@@ -65,5 +65,12 @@ module ConverterSpec
       # To ensure we can use the converter with Bool? type.
       converter.to_db(nil).should eq(nil)
     end
+
+    it "converts from uuid" do
+      converter = Clear::Model::Converter::UUIDConverter
+      some_uuid = UUID.random
+      converter.to_db(some_uuid).should eq(some_uuid.to_s)
+      converter.to_db(nil).should eq(nil)
+    end
   end
 end

--- a/src/clear/extensions/uuid/uuid.cr
+++ b/src/clear/extensions/uuid/uuid.cr
@@ -22,7 +22,11 @@ class Clear::Model::Converter::UUIDConverter
   end
 
   def self.to_db(x : UUID?)
-    x.to_s
+    if x.nil?
+      nil
+    else
+      x.to_s
+    end
   end
 end
 


### PR DESCRIPTION
Right now when you insert an uuid property with nil, it transforms it into an empty string instead.
This PR fixes that, now inserting an uuid with nil inserts NULL in the database.