### PR TITLE
simplify time converter

### DIFF
--- a/src/clear/model/converters/time_converter.cr
+++ b/src/clear/model/converters/time_converter.cr
@@ -12,16 +12,8 @@ class Clear::Model::Converter::TimeConverter
       case time
       when /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+/ # 2020-02-22 09:11:42.476953
         Time.parse_local(x.to_s, "%F %X.%L")
-      when /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z/ # 2020-02-22T09:11:42.476953Z
-        Time.parse(x.to_s, "%FT%X.%6NZ", Time::Location::UTC)
-      when /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\+[0-9]{2}:[0-9]{2}/ # 2020-02-24T11:05:28+07:00
-        Time.parse!(x.to_s, "%FT%X%z")
-      when /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z/ # 2020-02-24T11:05:28Z
-        Time.parse(x.to_s, "%FT%XZ", Time::Location::UTC)
-      when /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}Z/ # 2020-02-11T17:54:49.000Z
-        Time.parse(x.to_s, "%FT%X.%NZ", Time::Location::UTC)
       else
-        raise Time::Format::Error.new("Bad format for Time: #{time}")
+        Time::Format::RFC_3339.parse(time)
       end
     end
   end


### PR DESCRIPTION
I've managed to simplify a bit the time converter, now it only uses a regex for "2020-02-22 09:11:42.476953" which is not an RFC_3339 format, all the other cases (and more since I had other format errors) can be handled with the stdlib directly.

I've not touched the specs to show that parsing still works.