### PR TITLE
Crystal 0.35.0 fix; Procs literals require parens

### DIFF
--- a/src/clear/sql/transaction.cr
+++ b/src/clear/sql/transaction.cr
@@ -25,7 +25,7 @@ module Clear::SQL::Transaction
   end
 
   @@savepoint_uid : UInt64 = 0_u64
-  @@commit_callbacks = Hash( DB::Database, Array(DB::Database -> Void) ).new { [] of DB::Database -> Void }
+  @@commit_callbacks = Hash( DB::Database, Array(DB::Database -> Void) ).new { [] of (DB::Database -> Void) }
 
   # Check whether the current pair of fiber/connection is in transaction
   # block or not.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Crystal 0.35.0 changed something with Proc parsing to where Proc literals now require parens around them, this PR fixes that.

## Motivation and Context
Crystal 0.35.0 breaking change

## How Has This Been Tested?
It has been tested in my environment and is working with this change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
