### PR TITLE
Upgrade to Crystal 0.35.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,26 +1,26 @@
-version: 1.0
+version: 2.0
 shards:
   admiral:
-    github: jwaldrip/admiral.cr
-    commit: d11fc4863154f3dbd933421bdf45d356a2550e07
+    git: https://github.com/jwaldrip/admiral.cr.git
+    version: 1.11.2+git.commit.c3c3467953654554b72c24e7b853d6fbb23f10c0
 
   ameba:
-    github: veelenga/ameba
-    commit: 976f9729d5c7008925464f9a7da450c314807511
+    git: https://github.com/veelenga/ameba.git
+    version: 0.12.1+git.commit.f1adf14527ad37608f0466f81ac0b4ea210febee
 
   db:
-    github: crystal-lang/crystal-db
-    version: 0.8.0
+    git: https://github.com/crystal-lang/crystal-db.git
+    version: 0.9.0
 
   generate:
-    github: anykeyh/generate.cr
-    commit: 27a59d663ded8ce39a361e3a88b8dd747f59ce42
+    git: https://github.com/anykeyh/generate.cr.git
+    version: 0.1.0+git.commit.27a59d663ded8ce39a361e3a88b8dd747f59ce42
 
   inflector:
-    github: phoffer/inflector.cr
+    git: https://github.com/phoffer/inflector.cr.git
     version: 0.1.8
 
   pg:
-    github: will/crystal-pg
-    commit: cafebf8ae9477e7e50bd3e1281d66d8a519d645f
+    git: https://github.com/will/crystal-pg.git
+    version: 0.21.1+git.commit.cafe111fc28e366c219144d5f656c3718d7357dd
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -18,7 +18,7 @@ def initdb
   Clear::SQL.init("postgres://postgres@localhost/clear_spec", connection_pool_size: 5)
   Clear::SQL.init("secondary", "postgres://postgres@localhost/clear_secondary_spec", connection_pool_size: 5)
 
-  Clear.logger.level = {% if flag?(:quiet) %} ::Logger::ERROR {% else %} Clear.logger.level = ::Logger::DEBUG {% end %}
+  {% if flag?(:quiet) %} Log.setup(:error) {% else %} Log.setup(:debug) {% end %}
 end
 
 def reinit_migration_manager

--- a/src/clear/core.cr
+++ b/src/clear/core.cr
@@ -1,11 +1,3 @@
-module Clear
-  class_property logger : Logger = Logger.new(STDOUT)
-end
-
-
-
-
-
 # Require everything except the extensions and the CLI
 require "./version"
 require "./util"

--- a/src/clear/migration/migration.cr
+++ b/src/clear/migration/migration.cr
@@ -106,7 +106,7 @@ module Clear::Migration
     Clear::Migration::Manager.instance.ensure_ready
 
     Clear::SQL.transaction do
-      Clear.logger.info("[#{dir.to_s}] #{self.class.name}")
+      Log.info { "[#{dir.to_s}] #{self.class.name}" }
 
       change(dir)
 

--- a/src/clear/sql/logger.cr
+++ b/src/clear/sql/logger.cr
@@ -59,7 +59,7 @@ module Clear::SQL::Logger
     o = yield
     elapsed_time = Time.monotonic - start_time
 
-    Clear.logger.debug(("[" + Clear::SQL::Logger.display_time(elapsed_time.to_f).colorize.bold.white.to_s + "] #{SQL::Logger.colorize_query(sql)}"))
+    Log.debug { "[" + Clear::SQL::Logger.display_time(elapsed_time.to_f).colorize.bold.white.to_s + "] #{SQL::Logger.colorize_query(sql)}" }
 
     o
   rescue e


### PR DESCRIPTION
## Description
Upgrade to Crystal 0.35.0

## Motivation and Context
Dependencies just need to be updated and there was an easy fix for deprecation warnings coming from https://github.com/crystal-lang/crystal/pull/8847

## How Has This Been Tested?
Passing the test suite