### PR TITLE
Add create/update/set from JSON

### DIFF
--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -82,7 +82,7 @@ module ModelSpec
 
     column first_name : String
     column last_name : String?
-    column middle_name : String?
+    column middle_name : String?, mass_assign: false
     column active : Bool?
 
     column notification_preferences : JSON::Any, presence: false
@@ -849,9 +849,7 @@ module ModelSpec
   describe "Clear::Model::JSONDeserialize" do
     it "can create a model json IO" do
       user_body = {first_name: "foo"}
-      io = IO::Memory.new
-      io << user_body.to_json
-      io.rewind
+      io = IO::Memory.new user_body.to_json
       user = User.from_json(io)
       user.first_name.should eq user_body["first_name"]
     end
@@ -901,6 +899,30 @@ module ModelSpec
         u4_body = {first_name: "Aaron"}
         u4 = u3.update_from_json!(u4_body.to_json)
         u4.first_name.should eq(u4_body["first_name"])
+      end
+    end
+  end
+
+  describe "Clear::Model::HasColumns mass_assign" do
+    it "should do mass_assignment" do
+      temporary do
+        reinit
+        u1_body = {first_name: "George", last_name: "Dream", middle_name: "Sapnap"}
+        u1 = User.create_from_json(u1_body.to_json, trusted: true)
+        u1.first_name.should eq u1_body["first_name"]
+        u1.last_name.should eq u1_body["last_name"]
+        u1.middle_name.should eq u1_body["middle_name"]
+      end
+    end
+
+    it "should not do mass_assignment" do
+      temporary do
+        reinit
+        u1_body = {first_name: "George", last_name: "Dream", middle_name: "Sapnap"}
+        u1 = User.create_from_json(u1_body.to_json)
+        u1.first_name.should eq u1_body["first_name"]
+        u1.last_name.should eq u1_body["last_name"]
+        u1.middle_name.should be_nil
       end
     end
   end

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -374,7 +374,7 @@ module ModelSpec
           reinit
 
           u = User.new({first_name: "John"})
-          post = Post.new({user: u, title: "some post" })
+          post = Post.new({user: u, title: "some post"})
 
           u.save!
           post.save! # Exception
@@ -842,6 +842,65 @@ module ModelSpec
           users.map(&.first_name).should eq ["user0", "user2", "user4", "user6", "user8"]
           users.total_entries.should eq 8
         end
+      end
+    end
+  end
+
+  describe "Clear::Model::JSONDeserialize" do
+    it "can create a model json IO" do
+      user_body = {first_name: "foo"}
+      io = IO::Memory.new
+      io << user_body.to_json
+      io.rewind
+      user = User.from_json(io)
+      user.first_name.should eq user_body["first_name"]
+    end
+
+    it "can create a new model instance from json" do
+      user_body = {first_name: "Steve"}
+      user = User.from_json(user_body.to_json)
+      user.first_name.should eq(user_body["first_name"])
+    end
+
+    it "sets fields from json" do
+      user_body = {first_name: "Steve"}
+      update_body = {first_name: "stevo"}
+      user = User.new(user_body)
+      user.set_from_json(update_body.to_json)
+      user.first_name.should eq update_body["first_name"]
+    end
+
+    it "sets nillable fields to nil" do
+      user = User.new({first_name: "Foo", last_name: "Bar"})
+      user.set_from_json({last_name: nil}.to_json)
+      user.last_name.should be_nil
+    end
+
+    it "does not set unnillable fields to nil" do
+      user_body = {first_name: "Foo"}
+      user = User.new(user_body)
+      user.set_from_json({first_name: nil}.to_json)
+      user.first_name.should eq user_body["first_name"]
+    end
+
+    it "create and update a model from json" do
+      temporary do
+        reinit
+        u1_body = {first_name: "George"}
+        u1 = User.create_from_json(u1_body.to_json)
+        u1.first_name.should eq u1_body["first_name"]
+
+        u2_body = {first_name: "Eliza"}
+        u2 = User.create_from_json!(u2_body.to_json)
+        u2.first_name.should eq(u2_body["first_name"])
+
+        u3_body = {first_name: "Angelica"}
+        u3 = u2.update_from_json(u3_body.to_json)
+        u3.first_name.should eq(u3_body["first_name"])
+
+        u4_body = {first_name: "Aaron"}
+        u4 = u3.update_from_json!(u4_body.to_json)
+        u4.first_name.should eq(u4_body["first_name"])
       end
     end
   end

--- a/src/clear/model/json_deserialize.cr
+++ b/src/clear/model/json_deserialize.cr
@@ -29,20 +29,23 @@ macro columns_to_instance_vars
     {% end %}
 
     # Create a new empty model and fill the columns with object's instance variables
-    def create
-      assign_columns({{@type}}.new)
+    # Trusted flag set to true will allow mass assignment without protection
+    def create(trusted : Bool)
+      assign_columns({{@type}}.new, trusted)
     end
 
     # Update the inputted model and assign the columns with object's instance variables
-    def update(model)
-      assign_columns(model)
+    # Trusted flag set to true will allow mass assignment without protection
+    def update(model, trusted : Bool)
+      assign_columns(model, trusted)
     end
 
     macro finished
       # Assign properties to the model inputted with object's instance variables
-      protected def assign_columns(model)
+      # Trusted flag set to true will allow mass assignment without protection
+      protected def assign_columns(model, trusted : Bool)
         {% for name, settings in COLUMNS %}
-          if self.{{name.id}}_present?
+          if ({{ settings[:mass_assign] }} || trusted) && self.{{name.id}}_present?
             %value = self.{{name.id}}
             {% if settings[:type].resolve.nilable? %}
               model.{{name.id}} = %value
@@ -57,19 +60,20 @@ macro columns_to_instance_vars
     end
   end
 
-  # Create a new empty model and fill the columns from json
+  # Create a new empty model and fill the columns from json. Returns the new model
   #
-  # Returns the new model
-  def self.from_json(string_or_io : String | IO)
-    Assigner.from_json(string_or_io).create
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def self.from_json(string_or_io : String | IO, trusted : Bool = false)
+    Assigner.from_json(string_or_io).create(trusted)
   end
 
   # Create a new model from json and save it. Returns the model.
   #
   # The model may not be saved due to validation failure;
   # check the returned model `errors?` and `persisted?` flags.
-  def self.create_from_json(string_or_io : String | IO)
-    mdl = self.from_json(string_or_io)
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def self.create_from_json(string_or_io : String | IO, trusted : Bool = false)
+    mdl = self.from_json(string_or_io, trusted)
     mdl.save
     mdl
   end
@@ -78,24 +82,28 @@ macro columns_to_instance_vars
   #
   # Returns the newly inserted model
   # Raises an exception if validation failed during the saving process.
-  def self.create_from_json!(string_or_io : String | IO)
-    self.from_json(string_or_io).save!
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def self.create_from_json!(string_or_io : String | IO, trusted : Bool = false)
+    self.from_json(string_or_io, trusted).save!
   end
 
   # Set the fields from json passed as argument
-  def set_from_json(string_or_io : String | IO)
-    Assigner.from_json(string_or_io).update(self)
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def set_from_json(string_or_io : String | IO, trusted : Bool = false)
+    Assigner.from_json(string_or_io).update(self, trusted)
   end
 
   # Set the fields from json passed as argument and call `save` on the object
-  def update_from_json(string_or_io : String | IO)
-    mdl = set_from_json(string_or_io)
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def update_from_json(string_or_io : String | IO, trusted : Bool = false)
+    mdl = set_from_json(string_or_io, trusted)
     mdl.save
     mdl
   end
 
   # Set the fields from json passed as argument and call `save!` on the object
-  def update_from_json!(string_or_io : String | IO)
-    set_from_json(string_or_io).save!
+  # Trusted flag set to true will allow mass assignment without protection, FALSE by default
+  def update_from_json!(string_or_io : String | IO, trusted : Bool = false)
+    set_from_json(string_or_io, trusted).save!
   end
 end

--- a/src/clear/model/json_deserialize.cr
+++ b/src/clear/model/json_deserialize.cr
@@ -1,0 +1,101 @@
+# This module declare all the methods and macro related to deserializing json in `Clear::Model`
+module Clear::Model::JSONDeserialize
+  macro included
+    macro included # When included into Model
+      macro inherited #Polymorphism
+        macro finished
+          columns_to_instance_vars
+        end
+      end
+
+      macro finished
+        columns_to_instance_vars
+      end
+    end
+  end
+end
+
+# Used internally to deserialise json
+macro columns_to_instance_vars
+  # :nodoc:
+  struct Assigner
+    include JSON::Serializable
+
+    {% for name, settings in COLUMNS %}
+      @[JSON::Field(presence: true)]
+      getter {{name.id}} : {{settings[:type]}} {% unless settings[:type].resolve.nilable? %} | Nil {% end %}
+      @[JSON::Field(ignore: true)]
+      getter? {{name.id}}_present : Bool
+    {% end %}
+
+    # Create a new empty model and fill the columns with object's instance variables
+    def create
+      assign_columns({{@type}}.new)
+    end
+
+    # Update the inputted model and assign the columns with object's instance variables
+    def update(model)
+      assign_columns(model)
+    end
+
+    macro finished
+      # Assign properties to the model inputted with object's instance variables
+      protected def assign_columns(model)
+        {% for name, settings in COLUMNS %}
+          if self.{{name.id}}_present?
+            %value = self.{{name.id}}
+            {% if settings[:type].resolve.nilable? %}
+              model.{{name.id}} = %value
+            {% else %}
+              model.{{name.id}} = %value unless %value.nil?
+            {% end %}
+          end
+        {% end %}
+
+        model
+      end
+    end
+  end
+
+  # Create a new empty model and fill the columns from json
+  #
+  # Returns the new model
+  def self.from_json(string_or_io : String | IO)
+    Assigner.from_json(string_or_io).create
+  end
+
+  # Create a new model from json and save it. Returns the model.
+  #
+  # The model may not be saved due to validation failure;
+  # check the returned model `errors?` and `persisted?` flags.
+  def self.create_from_json(string_or_io : String | IO)
+    mdl = self.from_json(string_or_io)
+    mdl.save
+    mdl
+  end
+
+  # Create a new model from json and save it. Returns the model.
+  #
+  # Returns the newly inserted model
+  # Raises an exception if validation failed during the saving process.
+  def self.create_from_json!(string_or_io : String | IO)
+    self.from_json(string_or_io).save!
+  end
+
+  # Set the fields from json passed as argument
+  def set_from_json(string_or_io : String | IO)
+    Assigner.from_json(string_or_io).update(self)
+  end
+
+  # Set the fields from json passed as argument and call `save` on the object
+  def update_from_json(string_or_io : String | IO)
+    mdl = set_from_json(string_or_io)
+    mdl.save
+    mdl
+  end
+
+  # Set the fields from json passed as argument and call `save!` on the object
+  def update_from_json!(string_or_io : String | IO)
+    set_from_json(string_or_io).save!
+  end
+end

--- a/src/clear/model/model.cr
+++ b/src/clear/model/model.cr
@@ -20,6 +20,7 @@ module Clear::Model
   include Clear::Model::ClassMethods
   include Clear::Model::HasFactory
   include Clear::Model::Initializer
+  include Clear::Model::JSONDeserialize
 
   getter cache : Clear::Model::QueryCache?
 

--- a/src/clear/model/modules/has_columns.cr
+++ b/src/clear/model/modules/has_columns.cr
@@ -23,7 +23,7 @@ module Clear::Model::HasColumns
   # to the given value, while the `changed?` flag remains false.
   # If you call save on a persisted model, the reset columns won't be
   # commited in the UPDATE query.
-  def reset( **t : **T ) forall T
+  def reset(**t : **T) forall T
     # Dev note:
     # ---------
     # The current implementation of reset is overriden on finalize (see below).
@@ -32,22 +32,21 @@ module Clear::Model::HasColumns
   end
 
   # See `reset(**t : **T)`
-  def reset( h : Hash(String, _) )
+  def reset(h : Hash(String, _))
   end
 
   # See `reset(**t : **T)`
-  def reset( h : Hash(Symbol, _) )
+  def reset(h : Hash(Symbol, _))
   end
-
 
   # Set one or multiple columns to a specific value
   # This two are equivalents:
   #
   # ```
-  #   model.set(a: 1)
-  #   model.a = 1
+  # model.set(a: 1)
+  # model.a = 1
   # ```
-  def set( ** t : **T ) forall T
+  def set(**t : **T) forall T
     # Dev note:
     # ---------
     # The current implementation of set is overriden on finalize (see below).
@@ -56,20 +55,19 @@ module Clear::Model::HasColumns
   end
 
   # See `set(**t : **T)`
-  def set( h : Hash(String, _) )
+  def set(h : Hash(String, _))
   end
 
   # See `set(**t : **T)`
-  def set( h : Hash(Symbol, _) )
+  def set(h : Hash(Symbol, _))
   end
-
 
   # Access to direct SQL attributes given by the request used to build the model.
   # Access is read only and updating the model columns will not apply change to theses columns.
   #
   # ```
-  #   model = Model.query.select("MIN(id) as min_id").first(fetch_columns: true)
-  #   id = model["min_id"].to_i32
+  # model = Model.query.select("MIN(id) as min_id").first(fetch_columns: true)
+  # id = model["min_id"].to_i32
   # ```
   def [](x) : ::Clear::SQL::Any
     attributes[x]
@@ -86,14 +84,14 @@ module Clear::Model::HasColumns
 
   # Returns the current hash of the modified values:
   #
-  #```
+  # ```
   # model = Model.query.first!
   # model.update_h # => {}
   # model.first_name = "hello"
   # model.update_h # => { "first_name" => "hello" }
   # model.save!
   # model.update_h # => {}
-  #```
+  # ```
   def update_h
     {} of String => ::Clear::SQL::Any
   end
@@ -106,7 +104,7 @@ module Clear::Model::HasColumns
   # ```
   # # Assuming our model has a primary key, a first name and last name and two timestamp columns:
   # model = Model.query.select("first_name, last_name").first!
-  # model.to_h # => { "first_name" => "Johnny", "last_name" => "Walker" }
+  # model.to_h             # => { "first_name" => "Johnny", "last_name" => "Walker" }
   # model.to_h(full: true) # => {"id" => nil, "first_name" => "Johnny", "last_name" => "Walker", "created_at" => nil, "updated_at" => nil}
   # ```
   def to_h(full = false)
@@ -144,7 +142,11 @@ module Clear::Model::HasColumns
   # During validation before saving, the presence will not be checked on this field
   #   and Clear will try to insert without the field value.
   #
-  macro column(name, primary = false, converter = nil, column_name = nil, presence = true)
+  # * `mass_assign : Bool (default = true)`: Use this option to turn on/ off mass assignment
+  #   when instantiating or updating a new model from json through `.from_json` methods from
+  #   the `Clear::Model::JSONDeserialize` module.
+  #
+  macro column(name, primary = false, converter = nil, column_name = nil, presence = true, mass_assign = true)
     {% _type = name.type %}
     {%
       unless converter
@@ -165,20 +167,22 @@ module Clear::Model::HasColumns
         else
           raise "Unknown: #{_type}, #{_type.class}"
         end
-      end %}
+      end
+    %}
 
     {%
       db_column_name = column_name == nil ? name.var : column_name.id
 
       COLUMNS["#{db_column_name.id}"] = {
-         type:      _type,
-         primary:   primary,
-         converter: converter,
-         db_column_name: "#{db_column_name.id}",
-         crystal_variable_name: name.var,
-         presence:  presence,
-       }
-      %}
+        type:                  _type,
+        primary:               primary,
+        converter:             converter,
+        db_column_name:        "#{db_column_name.id}",
+        crystal_variable_name: name.var,
+        presence:              presence,
+        mass_assign:           mass_assign,
+      }
+    %}
   end
 
   # :nodoc:
@@ -193,8 +197,8 @@ module Clear::Model::HasColumns
       {% has_db_default = !settings[:presence] %}
       {% converter = Clear::Model::Converter::CONVERTERS[settings[:converter]] %}
       {% if converter == nil %}
-        {% raise "No converter found for `#{settings[:converter].id}`.\n"+
-                 "The type is probably not supported natively by Clear.\n"+
+        {% raise "No converter found for `#{settings[:converter].id}`.\n" +
+                 "The type is probably not supported natively by Clear.\n" +
                  "Please refer to the manual to create a custom converter." %}
       {% end %}
 


### PR DESCRIPTION
Co-authored-by: Caspian Baska <caspian@place.tech>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add support for creating and updating models from json, with mass assignment protection.
- These have been documented inline
- The model methods added are listed as follows:
`Model.from_json(json, trusted=true)`
`Model#set_from_json(json, trusted=false)`
`Model.create_from_json(json, trusted=false)`
`Model.create_from_json!(json, trusted=false)`
`Model#update_from_json(json, trusted=false)`
`Model#update_from_json!(json, trusted=false)`

- In the `column` macro, `mass_assign : Bool (default = true`) as an additional params has been added. This allows for protecting mass assignment when instantiating or updating a new model from json through `.from_json` methods from this module. Since `trusted` is false by default, mass assignment protection will be active whenever mass_assign is set to false for any column. This can be bypassed by setting `trusted: true` as a second argument in the above methods

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Performance is boosted markedly.

```
require "benchmark"

class BenchmarkModel
  include Clear::Model

  column a : Float64?
  column b : String
  column c : String
  column d : Int32
end

test_json = {a: 1.2, b: "hello friend", c: "bye friend", d: 404}.to_json

Benchmark.ips(warmup: 2) do |x|
  x.report "JSON::Any" do
    BenchmarkModel.new(JSON.parse(test_json))
  end
  x.report "from_json" do
    BenchmarkModel.from_json(test_json)
  end
end
```

The benchmark comparison between the two types of data creation/ updating, with output --release has the following stats
```
JSON::Any 559.12k (  1.79µs) (± 6.68%)  2.29kB/op   1.63× slower
from_json 908.65k (  1.10µs) (± 6.76%)  1.39kB/op        fastest
```

- Mass assignment is only needed in `.from_json` this is the only time we don't know what is in the data used to instantiate the model (in this case the JSON payload). Rails had support for this in the form of [**strong parameters**](https://brakemanscanner.org/docs/warning_types/mass_assignment/).

<!--- If it fixes an open issue, please link to the issue here. -->
- Resolves #107 
- Resolves #26 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Unit test added as `describe "Clear::Model::JSONDeserialize"` to `spec/model/model_spec.cr`

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- All tests passed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.