### PR TITLE
get rid of deprecated logger class

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,9 +406,8 @@ Clear is offering SQL logging tools, with SQL syntax colorizing in your terminal
 
 For activation, simply setup the logger to `DEBUG` level !
 
-
 ```
-Clear.logger.level = ::Logger::DEBUG
+Log.builder.bind "clear.*", :debug, Log::IOBackend.new(STDOUT)
 ```
 
 ### Save & validation

--- a/sample/benchmark/model.cr
+++ b/sample/benchmark/model.cr
@@ -5,8 +5,6 @@ require "benchmark"
 `echo "DROP DATABASE IF EXISTS benchmark_clear;" | psql -U postgres`
 `echo "CREATE DATABASE benchmark_clear;" | psql -U postgres`
 Clear::SQL.init("postgres://postgres@localhost/benchmark_clear")
-# Setting log level to DEBUG will allow you to see the requests made by the system
-# Clear.logger.level = ::Logger::DEBUG
 
 init = <<-SQL
   CREATE TABLE benchmark (id serial PRIMARY KEY NOT NULL, y int);

--- a/sample/cli/cli.cr
+++ b/sample/cli/cli.cr
@@ -1,7 +1,6 @@
 require "../../src/clear"
 
 def initdb
-  Clear.logger.level = ::Logger::INFO
   Clear::SQL.init("postgres://postgres@localhost/clear_spec")
 end
 

--- a/sample/wiki/getting_started.cr
+++ b/sample/wiki/getting_started.cr
@@ -7,8 +7,6 @@ require "../../src/clear"
 
 # Initialize the connection
 Clear::SQL.init("postgres://postgres@localhost/sample_for_wiki")
-# Setting log level to DEBUG will allow you to see the requests made by the system
-Clear.logger.level = ::Logger::DEBUG
 
 # Because it's a step by step tutorial
 def pause

--- a/src/clear.cr
+++ b/src/clear.cr
@@ -1,5 +1,3 @@
-require "logger"
-
 # # Welcome to Clear ORM !
 #
 # Clear ORM is currently in heavy development.

--- a/src/clear/cli/command.cr
+++ b/src/clear/cli/command.cr
@@ -13,7 +13,6 @@ module Clear::CLI::Command
 
     def run
       Colorize.enabled = !flags.no_color
-      Clear.logger.level = ::Logger::DEBUG if flags.verbose
 
       run_impl
     end

--- a/src/clear/core.cr
+++ b/src/clear/core.cr
@@ -1,5 +1,6 @@
 # Require everything except the extensions and the CLI
 require "./version"
+require "./log"
 require "./util"
 require "./error_messages"
 require "./seed"

--- a/src/clear/log.cr
+++ b/src/clear/log.cr
@@ -1,0 +1,5 @@
+require "log"
+
+module Clear
+  Log = ::Log.for "clear"
+end

--- a/src/clear/migration/manager.cr
+++ b/src/clear/migration/manager.cr
@@ -120,13 +120,13 @@ class Clear::Migration::Manager
     end
 
     if operations.empty?
-      Clear.logger.debug("Nothing to do.")
+      Log.debug { "Nothing to do." }
       return
     end
 
-    Clear.logger.debug("Migrations will be applied (in this order):")
+    Log.debug { "Migrations will be applied (in this order):" }
     operations.each do |(uid, d)|
-      Clear.logger.debug("#{d.up? ? "[ UP ]" : "[DOWN]"} #{uid} - #{find(uid).class.name}")
+      Log.debug { "#{d.up? ? "[ UP ]" : "[DOWN]"} #{uid} - #{find(uid).class.name}" }
     end
 
     operations.each do |(uid, d)|

--- a/src/clear/sql/logger.cr
+++ b/src/clear/sql/logger.cr
@@ -1,5 +1,4 @@
 require "colorize"
-require "logger"
 require "benchmark"
 
 module Clear::SQL::Logger

--- a/templates/kemal/src/app.ecr
+++ b/templates/kemal/src/app.ecr
@@ -11,8 +11,6 @@ module Application
   end
 end
 
-Clear.logger.level = ::Logger::DEBUG if Application.env == "development"
-
 require "./db/init.cr"
 
 require "./views/**"


### PR DESCRIPTION
and code cleanup

Also, this will allow doing something like this:

```crystal

log_file =
  case ENV["KEMAL_ENV"]
  when "production"
    File.new("#{__DIR__}/log/clear.log", "a+")
  else
    STDOUT
  end

Log.builder.bind "clear.*", :debug, Log::IOBackend.new(log_file)

```