### PR TITLE
Add type JSON::Builder to json in .to_json

### DIFF
--- a/src/clear/extensions/core_ext.cr
+++ b/src/clear/extensions/core_ext.cr
@@ -3,13 +3,13 @@ require "base64"
 # Extension of some objects outside of Clear ("Monkey Patching")
 
 struct Char
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.string("#{self}")
   end
 end
 
 struct PG::Interval
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("microseconds") { json.number microseconds }
       json.field("days") { json.number days }
@@ -33,7 +33,7 @@ end
 
 struct PG::Geo::Box
   # :nodoc:
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("x1") { json.number x1 }
       json.field("x2") { json.number x2 }
@@ -44,7 +44,7 @@ struct PG::Geo::Box
 end
 
 struct PG::Geo::LineSegment
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("x1") { json.number x1 }
       json.field("x2") { json.number x2 }
@@ -55,7 +55,7 @@ struct PG::Geo::LineSegment
 end
 
 struct PG::Geo::Point
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("x") { json.number x }
       json.field("y") { json.number y }
@@ -64,7 +64,7 @@ struct PG::Geo::Point
 end
 
 struct PG::Geo::Line
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("a") { json.number a }
       json.field("b") { json.number b }
@@ -74,7 +74,7 @@ struct PG::Geo::Line
 end
 
 struct PG::Geo::Circle
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("x") { json.number x }
       json.field("y") { json.number y }
@@ -84,12 +84,12 @@ struct PG::Geo::Circle
 end
 
 struct PG::Geo::Path
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.field("points") do
         json.array do
           points.each do
-            points.to_json(json)
+            points.to_json(json : ::JSON::Builder)
           end
         end
       end
@@ -99,11 +99,11 @@ struct PG::Geo::Path
 end
 
 struct PG::Geo::Polygon
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.object do
       json.array do
         points.each do
-          points.to_json(json)
+          points.to_json(json : ::JSON::Builder)
         end
       end
     end
@@ -111,7 +111,7 @@ struct PG::Geo::Polygon
 end
 
 struct Slice(T)
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     s = String::Builder.new
     to_s(s)
     json.string(Base64.strict_encode(s.to_s))
@@ -119,7 +119,7 @@ struct Slice(T)
 end
 
 struct PG::Numeric
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     s = String::Builder.new
     to_s(s)
     json.string(s.to_s)
@@ -127,7 +127,7 @@ struct PG::Numeric
 end
 
 struct BigDecimal
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.string(to_s)
   end
 end

--- a/src/clear/extensions/enum/enum.cr
+++ b/src/clear/extensions/enum/enum.cr
@@ -20,7 +20,7 @@ module Clear
       @value.to_sql
     end
 
-    def to_json(json)
+    def to_json(json : ::JSON::Builder)
       json.string(@value)
     end
 

--- a/src/clear/extensions/uuid/uuid.cr
+++ b/src/clear/extensions/uuid/uuid.cr
@@ -1,5 +1,5 @@
 struct UUID
-  def to_json(json)
+  def to_json(json : ::JSON::Builder)
     json.string(to_s)
   end
 end

--- a/src/clear/model/modules/has_columns.cr
+++ b/src/clear/model/modules/has_columns.cr
@@ -421,7 +421,7 @@ module Clear::Model::HasColumns
       JSON.build{ |json| to_json(json, emit_nulls) }
     end
 
-    def to_json(json, emit_nulls = false)
+    def to_json(json : ::JSON::Builder, emit_nulls = false)
       json.object do
         {% for name, settings in COLUMNS %}
         if emit_nulls || @{{settings[:crystal_variable_name]}}_column.defined?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add type for `json` param in `def to_json(json); end;`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- When `.to_json` is used on Union types, especially IO Types || ::JSON::Builder, type can be casted incorrectly. By specifying ::JSON::Builder, this issue can be avoided.
- This issue occurs when `clear` is integrated with `spider-gazelle`
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
- All specs pass
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
