### PR TITLE
Fix has_one getter for nilable type

### DIFF
--- a/spec/model/relations/fixture.cr
+++ b/spec/model/relations/fixture.cr
@@ -45,6 +45,7 @@ module RelationSpec
     has_one user_info : UserInfo, foreign_key: "user_id"
     # Same...
     has_many user_infos : UserInfo, foreign_key: "user_id"
+    has_one user_info_nilable : UserInfo?, foreign_key: "user_id"
 
     has_many posts : Post, foreign_key: "user_id"
 

--- a/src/clear/model/modules/relations/has_one_macro.cr
+++ b/src/clear/model/modules/relations/has_one_macro.cr
@@ -61,11 +61,11 @@ module Clear::Model::Relations::HasOneMacro
 
       {% if nilable %}
         def {{method_name}}! : {{relation_type}}
-          if model = self.{{method_name}}.nil?
+          if model = self.{{method_name}}
+            model
+          else
             raise Clear::SQL::RecordNotFoundError.new
           end
-
-          model
         end # /  *!
       {% end %}
 


### PR DESCRIPTION
`has_one foo : Foo?` currently fails to compile with error `method must return ShardMetrics but it is returning Bool`. This patch is a simple fix. I didn't add a functional spec, but this should be good enough.