### PR TITLE
Allow specs to be run with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,21 @@ I hope one day we will cover all the features of PG here !
 
 ### Running Tests
 
-In order to run the test suite, you will need to have the PostgresSQL service locally available via a socket for access with psql. psql will attempt to use the 'postgres' user to create the test database. If you are working with a newly installed database that may not have the postgres user, this can be created with `createuser -s postgres`.
+#### With local PostgreSQL
+To run the test suite with local PostgreSQL, you will need to have the PostgresSQL service locally available via a socket for access with psql. psql will attempt to use the 'postgres' user to create the test database. If you are working with a newly installed database that may not have the postgres user, this can be created with `createuser -s postgres`.
+
+ Simply run crystal spec [--flags]
+
+ #### Using Docker
+To run the test suite with Docker, you will need to have Docker installed, then start the postgreSQL service container with the following command
+
+ `docker run --name clear_db -e POSTGRES_PASSWORD=password -h localhost -p 5432:5432 -d postgres`
+
+ Then simply load ENV=docker when running crystal spec [--flags]
+
+ `ENV=docker crystal spec [--flags]`
+
+ You can also specify the name of the container by loading it into `DB_NAME` environment variable
 
 ## Contributors ✨
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR will allow developers to run clear specs using Docker instead of installing PostgreSQL on their local system. Containerisation will not only help developers test clear without having to install PostgreSQL but also to allow for reproducibility due to the elimination of environmental differences.

In the future, this small change can be upgraded to setting up an entire docker-compose environment so that developers can run clear and clear specs without having to install either PostgreSQL or Crystal, this configuration can also be used for the CI/CD pipeline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- All specs passed

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
