### PR TITLE
Fix JSON::Deserialize not working with column_name field

### DIFF
--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -640,6 +640,17 @@ module ModelSpec
       user.first_name.should eq(user_body["first_name"])
     end
 
+    it "can create a new model instance with a column with column_name field" do
+      temporary do
+        reinit_example_models
+
+        u = User.create!({first_name: "John"})
+        p = Post.create_from_json({title: "A post", user_id: u.id}.to_json)
+        p.title.should eq("A post")
+        p.user_id.should eq(u.id)
+      end
+    end
+
     it "sets fields from json" do
       user_body = {first_name: "Steve"}
       update_body = {first_name: "stevo"}

--- a/src/clear/model/json_deserialize.cr
+++ b/src/clear/model/json_deserialize.cr
@@ -23,9 +23,9 @@ macro columns_to_instance_vars
 
     {% for name, settings in COLUMNS %}
       @[JSON::Field(presence: true)]
-      getter {{name.id}} : {{settings[:type]}} {% unless settings[:type].resolve.nilable? %} | Nil {% end %}
+      getter {{settings["crystal_variable_name"].id}} : {{settings[:type]}} {% unless settings[:type].resolve.nilable? %} | Nil {% end %}
       @[JSON::Field(ignore: true)]
-      getter? {{name.id}}_present : Bool
+      getter? {{settings["crystal_variable_name"].id}}_present : Bool
     {% end %}
 
     # Create a new empty model and fill the columns with object's instance variables
@@ -45,12 +45,12 @@ macro columns_to_instance_vars
       # Trusted flag set to true will allow mass assignment without protection
       protected def assign_columns(model, trusted : Bool)
         {% for name, settings in COLUMNS %}
-          if ({{ settings[:mass_assign] }} || trusted) && self.{{name.id}}_present?
-            %value = self.{{name.id}}
+          if ({{ settings[:mass_assign] }} || trusted) && self.{{settings["crystal_variable_name"].id}}_present?
+            %value = self.{{settings["crystal_variable_name"].id}}
             {% if settings[:type].resolve.nilable? %}
-              model.{{name.id}} = %value
+              model.{{settings["crystal_variable_name"].id}} = %value
             {% else %}
-              model.{{name.id}} = %value unless %value.nil?
+              model.{{settings["crystal_variable_name"].id}} = %value unless %value.nil?
             {% end %}
           end
         {% end %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Full detail of issue here: https://github.com/anykeyh/clear/issues/202
- This issue is a simple error due to the use of `COLUMNS` key for declaring instance variables, which is assigned as follows:

https://github.com/anykeyh/clear/blob/3bdaa44a7d0382fd8f6846afe8b8da95d58d9452/src/clear/model/modules/has_columns.cr#L174

The key is assigned to the method name, `name.var` by default but will be re-assigned to `column_name.id` if declared, which is the name of the column in the database, not the name of the method.

We need to use the method name and not the column_name, hence the change from `{{name.id}}` to `{{settings["crystal_variable_name"]}}`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Resolves https://github.com/anykeyh/clear/issues/202

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- All specs passed
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
