### PR TITLE
Allow mass_assignment option for belongs_to relation

### DIFF
--- a/spec/data/example_models.cr
+++ b/spec/data/example_models.cr
@@ -80,8 +80,8 @@ class Post
   has_many post_tags : PostTag, foreign_key: "post_id"
   has_many tag_relations : Tag, through: :post_tags, relation: :tag
 
-  belongs_to user : User, foreign_key_type: Int32
-  belongs_to category : Category?, foreign_key_type: Int32
+  belongs_to user : User, foreign_key_type: Int32, mass_assign: true
+  belongs_to category : Category?, foreign_key_type: Int32, mass_assign: false
 end
 
 class UserInfo

--- a/spec/model/model_spec.cr
+++ b/spec/model/model_spec.cr
@@ -719,6 +719,27 @@ module ModelSpec
         u1.middle_name.should be_nil
       end
     end
+
+    it "should do mass_assignment for belongs_to relation" do
+      temporary do
+        reinit_example_models
+
+        u = User.create!({first_name: "John"})
+        p = Post.create_from_json({title: "A post", user_id: u.id}.to_json)
+        p.user_id.should eq(u.id)
+      end
+    end
+
+    it "should not do mass_assignment for belongs_to relation" do
+      temporary do
+        reinit_example_models
+
+        u = User.create!({first_name: "John"})
+        c = Category.create!({name: "Nature"})
+        p = Post.create_from_json({title: "A post", user_id: u.id, category_id: c.id}.to_json)
+        p.category_id.should be_nil
+      end
+    end
   end
 
   describe "BigDecimal / Numeric column in Migration" do

--- a/src/clear/model/modules/has_relations.cr
+++ b/src/clear/model/modules/has_relations.cr
@@ -50,6 +50,7 @@ module Clear::Model::HasRelations
         presence: Bool,                     # For belongs_to, check or not the presence
 
         cache: Bool,                        # whether the model will cache the relation
+        mass_assign: Bool?                  # whether the model can be mass assigned on this field during deserialisation
       }
     end
   end
@@ -164,7 +165,7 @@ module Clear::Model::HasRelations
   # ```
   macro belongs_to(name, foreign_key = nil, cache = true, primary = false,
                    foreign_key_type = Int64, polymorphic = false,
-                   polymorphic_type_column = nil, presence = true)
+                   polymorphic_type_column = nil, presence = true, mass_assign = true)
 
     {%
       foreign_key = "#{foreign_key.id}" if foreign_key
@@ -196,8 +197,9 @@ module Clear::Model::HasRelations
         primary:  primary,
         presence: presence,
 
-        through: nil,
-        cache:   cache,
+        through:     nil,
+        cache:       cache,
+        mass_assign: mass_assign,
       }
     %}
   end

--- a/src/clear/model/modules/relations/belongs_to_macro.cr
+++ b/src/clear/model/modules/relations/belongs_to_macro.cr
@@ -14,11 +14,13 @@ module Clear::Model::Relations::BelongsToMacro
         primary = relation[:primary]
 
         nilable = relation[:nilable]
+
+        mass_assign = relation[:mass_assign]
       %}
 
       __define_association_cache__({{method_name}}, {{relation_type}})
 
-      column {{foreign_key}} : {{foreign_key_type}}{{ nilable ? "?".id : "".id }}, primary: {{primary}}, presence: false
+      column {{foreign_key}} : {{foreign_key_type}}{{ nilable ? "?".id : "".id }}, primary: {{primary}}, presence: false, mass_assign: {{mass_assign}}
 
       # :nodoc:
       def self.__relation_filter_{{method_name}}__(query)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- This PR allows mass_assign option for belongs_to relation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Currently mass_assign in the JSONDeserialize module only supports column but not the belongs_to relation which would be essential if belongs_to foreign_key is nilable.
- Please note, the example data used in the spec for this feature is dependent on this PR https://github.com/anykeyh/clear/pull/203

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- All specs passed
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
