### PR TITLE
Support latest PG version from will/crystal-pg#232

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,11 @@ version: 2.0
 shards:
   admiral:
     git: https://github.com/jwaldrip/admiral.cr.git
-    version: 1.11.4
+    version: 1.12.1
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.1
+    version: 0.14.3
 
   db:
     git: https://github.com/crystal-lang/crystal-db.git
@@ -22,5 +22,5 @@ shards:
 
   pg:
     git: https://github.com/will/crystal-pg.git
-    version: 0.23.1
+    version: 0.24.0
 

--- a/src/clear/model/converters/json_any_converter.cr
+++ b/src/clear/model/converters/json_any_converter.cr
@@ -7,6 +7,8 @@ module Clear::Model::Converter::JSON::AnyConverter
       nil
     when ::JSON::Any
       x
+    when ::JSON::PullParser
+      ::JSON::Any.new(x)
     else
       ::JSON.parse(x.to_s)
     end
@@ -44,10 +46,12 @@ module Clear
           x
         when String
           ::{{type}}.new(::JSON::PullParser.new(x))
+        when ::JSON::PullParser
+          ::{{type}}.new(x)
         when ::JSON::Any
           ::{{type}}.new(::JSON::PullParser.new(x.to_json))
         else
-          raise {{"Cannot convert to #{type} from \#{x.class}"}}
+          raise "Cannot convert to {{type}} from #{x.class}"
         end
       end
 

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -50,7 +50,7 @@ module Clear
                 Array(PG::Float64Array) | Array(PG::Int16Array) | Array(PG::Int32Array) |
                 Array(PG::Int64Array) | Array(PG::StringArray) | Array(PG::TimeArray) |
                 Array(PG::NumericArray) |
-                Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | BigDecimal | JSON::Any | JSON::Any::Type | PG::Geo::Box | PG::Geo::Circle |
+                Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | BigDecimal | JSON::PullParser | JSON::Any | JSON::Any::Type | PG::Geo::Box | PG::Geo::Circle |
                 PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point |
                 PG::Geo::Polygon | PG::Numeric | PG::Interval | Slice(UInt8) | String | Time |
                 UInt8 | UInt16 | UInt32 | UInt64 | Clear::Expression::UnsafeSql | UUID |


### PR DESCRIPTION
will/crystal-pg#232 - changes default postgres JSON fields from being read as JSON::Any to JSON::PullParser. Updated Clear to support that.

Also updated shards.lock file, though only pg needed to be updated to run into this problem.