### PR TITLE
Fix serialization of JSON::Any? nil values

### DIFF
--- a/spec/model/converters/json_converter_spec.cr
+++ b/spec/model/converters/json_converter_spec.cr
@@ -112,6 +112,11 @@ module JSONConverterSpec
       converter.to_column(JSON_DATA_SAMPLE).should eq(json_any)
     end
 
+    it "converts nil values to db" do
+      converter = Clear::Model::Converter::JSON::AnyConverter
+      converter.to_db(nil).should eq(nil)
+    end
+
     it "converts using json_serializable_converter" do
       temporary do
         reinit_migration_manager

--- a/src/clear/model/converters/json_any_converter.cr
+++ b/src/clear/model/converters/json_any_converter.cr
@@ -15,7 +15,7 @@ module Clear::Model::Converter::JSON::AnyConverter
   end
 
   def self.to_db(x : ::JSON::Any?)
-    x.to_json
+    x ? x.to_json : nil
   end
 end
 


### PR DESCRIPTION
## Description
Currently the literal string `'null'` is written to the database when a `nil` value is serialized.

Note that the `json_serializable_converter` macro already does the right thing: https://github.com/anykeyh/clear/blob/master/src/clear/model/converters/json_any_converter.cr#L59

## How Has This Been Tested?
A test has been added.
There were no existing tests for `Clear::Model::Converter::JSON::AnyConverter.to_db`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
