### PR TITLE
Registers generators to base

### DIFF
--- a/src/clear/cli.cr
+++ b/src/clear/cli.cr
@@ -36,7 +36,8 @@ module Clear
 
       define_version Clear::VERSION
       define_help
-
+      
+      register_sub_command generate, type: Clear::CLI::Generator
       register_sub_command migrate, type: Clear::CLI::Migration
       register_sub_command generate, type: Clear::CLI::Generator
       register_sub_command seed, type: Clear::CLI::Seed

--- a/src/clear/cli/generators/model.cr
+++ b/src/clear/cli/generators/model.cr
@@ -1,7 +1,7 @@
 require "generate"
 
 class Clear::CLI::Generator
-  register_sub_command "model:from_database", type: Model, description: "Create a new model and the first migration"
+  register_sub_command "model", type: Model, description: "Create a new model and the first migration"
 
   class Model < Admiral::Command
     include Clear::CLI::Command

--- a/src/clear/sql/sql.cr
+++ b/src/clear/sql/sql.cr
@@ -49,7 +49,7 @@ module Clear
     alias Any = Array(PG::BoolArray) | Array(PG::CharArray) | Array(PG::Float32Array) |
                 Array(PG::Float64Array) | Array(PG::Int16Array) | Array(PG::Int32Array) |
                 Array(PG::Int64Array) | Array(PG::StringArray) | Array(PG::TimeArray) |
-                Array(PG::NumericArray) |
+                Array(PG::NumericArray) | Array(PG::UUIDArray) |
                 Bool | Char | Float32 | Float64 | Int8 | Int16 | Int32 | Int64 | BigDecimal | JSON::PullParser | JSON::Any | JSON::Any::Type | PG::Geo::Box | PG::Geo::Circle |
                 PG::Geo::Line | PG::Geo::LineSegment | PG::Geo::Path | PG::Geo::Point |
                 PG::Geo::Polygon | PG::Numeric | PG::Interval | Slice(UInt8) | String | Time |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Registers generate commands to Base so that developers can create models and migrations.

## Motivation and Context
- When working with the CLI generating models requires a separate script. This is counter-intuitive and counter-productive. Instead proposes to have a single CLI script that can do both. 

## How Has This Been Tested?
- Built a single CLI from which I can run both generator commands and migration commands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. `bin/ameba` ran without alert.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
