### PR TITLE
Fix breakages caused by Crystal 1.13

### DIFF
--- a/src/clear/extensions/enum/migration.cr
+++ b/src/clear/extensions/enum/migration.cr
@@ -37,7 +37,7 @@ module Clear::Migration
     end
   end
 
-  module Clear::Migration::Helper
+  module Helper
     def create_enum(name : Clear::SQL::Symbolic, arr : Enumerable(T)) forall T
       self.add_operation(CreateEnum.new(name.to_s, arr.map(&.to_s)))
     end

--- a/src/clear/model/modules/has_relations.cr
+++ b/src/clear/model/modules/has_relations.cr
@@ -80,7 +80,7 @@ module Clear::Model::HasRelations
       polymorphic_type_column = "#{polymorphic_type_column.id}" if polymorphic_type_column
 
       if name.type.is_a?(Union) # Nilable?
-        nilable = name.type.types.map { |x| "#{x.id}" }.any? { |x| x == "Nil" || x == "::Nil"}
+        nilable = name.type.resolve.nilable?
         type = name.type.types.first
       else
         type = name.type
@@ -173,7 +173,7 @@ module Clear::Model::HasRelations
       nilable = false
 
       if name.type.is_a?(Union) # Nilable?
-        nilable = name.type.types.map { |x| "#{x.id}" }.any? { |x| x == "Nil" || x == "::Nil"}
+        nilable = name.type.resolve.nilable?
         type = name.type.types.first
       else
         type = name.type

--- a/src/clear/model/modules/has_relations.cr
+++ b/src/clear/model/modules/has_relations.cr
@@ -80,7 +80,7 @@ module Clear::Model::HasRelations
       polymorphic_type_column = "#{polymorphic_type_column.id}" if polymorphic_type_column
 
       if name.type.is_a?(Union) # Nilable?
-        nilable = name.type.types.map { |x| "#{x.id}" }.includes?("Nil")
+        nilable = name.type.types.map { |x| "#{x.id}" }.any? { |x| x == "Nil" || x == "::Nil"}
         type = name.type.types.first
       else
         type = name.type
@@ -173,7 +173,7 @@ module Clear::Model::HasRelations
       nilable = false
 
       if name.type.is_a?(Union) # Nilable?
-        nilable = name.type.types.map { |x| "#{x.id}" }.includes?("Nil")
+        nilable = name.type.types.map { |x| "#{x.id}" }.any? { |x| x == "Nil" || x == "::Nil"}
         type = name.type.types.first
       else
         type = name.type

--- a/src/clear/model/reflection/column.cr
+++ b/src/clear/model/reflection/column.cr
@@ -1,3 +1,5 @@
+require "./table"
+
 # Reflection of the columns using information_schema in postgreSQL.
 # TODO: Usage of view instead of model
 class Clear::Reflection::Column


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were 2 issues:

1. The first, 653c74c9b15a7d9f5f145279bbec5763fa28785b, was causing compilation to fail. I didn't investigate further because this module was clearly incorrectly (it was defining `Clear::Migration::Clear::Migration::Helper`).

2. The second issues only affected `has_many` and `belongs_to` associations which were nilable (and defined using the `?` shorthand). The reason for the breakage and a minimal fix is included in 0aa9beb7704728e37bfe07ce7c241bb3959b9660.  A more robust fix is then added in 8cc27f72235d55fd7c7cf4d09d2b0ddb9664d598, but with the caveat that some code may need to be updated with additional `require`s (so that the union type can be resolved in the macro). I would be happy to remove 8cc27f72235d55fd7c7cf4d09d2b0ddb9664d598 from this PR in order to get the minimal fix merged and then to suggest the refactoring later.

<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clear can't currently be used on Crystal 1.13.0 or above. Closes #230.

## How Has This Been Tested?

Tests have been run, and the code has been tested against a production codebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
