### PR TITLE
Fix compiler warnings related to Crystal 1.14

### DIFF
--- a/manual/model/transactions-and-save-points/connection-pool.md
+++ b/manual/model/transactions-and-save-points/connection-pool.md
@@ -12,7 +12,7 @@ begin
     # Clear automatically create a connection nº1 
     Clear::SQL.transaction do
       Clear::SQL.insert("tests", {id: 1}).execute
-      sleep 0.2 #< Wait and do not commit the transaction for now
+      sleep 0.2.seconds # Wait and do not commit the transaction for now
     end
   end
 
@@ -20,12 +20,12 @@ begin
 
   # Spawn a new fiber
   spawn do
-    sleep 0.1 #Wait a bit, to ensure than the first connection is inside a transaction
+    sleep 0.1.seconds # Wait a bit, to ensure than the first connection is inside a transaction
     # execute in connection nº2
     @@count = Clear::SQL.select.from("tests").count
   end
 
-  sleep 0.3 # Let the 2 fiber time to finish...
+  sleep 0.3.seconds # Let the 2 fiber time to finish...
 
   # The count is zero, because: it has been setup by the second fiber, which
   # called AFTER the insert but BEFORE the commit on the connection nº1

--- a/spec/sql/connection_pool_spec.cr
+++ b/spec/sql/connection_pool_spec.cr
@@ -19,7 +19,7 @@ module ConnectionPoolSpec
           spawn do
             Clear::SQL.transaction do
               Clear::SQL.insert("tests", {id: 1}).execute
-              sleep 0.2 # < The transaction is not yet commited
+              sleep 0.2.seconds # < The transaction is not yet commited
             end
           end
 
@@ -27,11 +27,11 @@ module ConnectionPoolSpec
 
           spawn do
             # Not inside the transaction so count must be zero since the transaction is not finished:
-            sleep 0.1
+            sleep 0.1.seconds
             @@count = Clear::SQL.select.from("tests").count
           end
 
-          sleep 0.3 # Let the 2 spawn finish...
+          sleep 0.3.seconds # Let the 2 spawn finish...
 
           @@count.should eq 0 # < If one, the connection pool got wrong with the fiber.
 

--- a/spec/sql/select/lock_spec.cr
+++ b/spec/sql/select/lock_spec.cr
@@ -19,7 +19,7 @@ module LockSpec
         Clear::SQL.select.from(:to_lock).pluck_col(:id).should eq [1]
       end
 
-      sleep(0.05) # Give hand to the other fiber. Now it should be not locked anymore?
+      sleep 0.05.seconds # Give hand to the other fiber. Now it should be not locked anymore?
       Clear::SQL.select.from(:to_lock).order_by("id", :asc).pluck_col(:id).should eq [1, 2]
     ensure
       Clear::SQL.execute("DROP TABLE to_lock")

--- a/src/clear/expression/expression.cr
+++ b/src/clear/expression/expression.cr
@@ -83,7 +83,7 @@ class Clear::Expression
       @value
     end
 
-    def to_json(b = nil)
+    def to_json(x = nil)
       @value
     end
   end


### PR DESCRIPTION
## Description

This fixes compiler warnings, which I've detailed in the commit commits. This should be a no-op change.

## Motivation and Context

Clean buids.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- In case of new features, please provide a proper documentation in `manual/` directory -->
- [ ] Manual of usage of the new feature.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. `bin/ameba` ran without alert.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
